### PR TITLE
Surface backend error details with "Unable to <action>: <reason>" messaging

### DIFF
--- a/src/__tests__/EntriesCard.test.ts
+++ b/src/__tests__/EntriesCard.test.ts
@@ -3,7 +3,8 @@ import { nextTick } from 'vue';
 import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query';
 import { mount, flushPromises } from '@vue/test-utils';
 
-vi.mock('../lib/customFetch', () => ({
+vi.mock('../lib/customFetch', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/customFetch')>()),
   customFetch: vi.fn(),
 }));
 
@@ -231,7 +232,7 @@ describe('EntriesCard', () => {
     await createButton!.trigger('click');
     await flushPromises();
 
-    expect(wrapper.text()).toContain('Failed to create entry');
+    expect(wrapper.text()).toContain('Unable to create entry');
     expect(wrapper.find('textarea').exists()).toBe(true);
   });
 

--- a/src/__tests__/customFetch.test.ts
+++ b/src/__tests__/customFetch.test.ts
@@ -159,17 +159,50 @@ describe('customFetch', () => {
     expect(fetchOptions.body).toBe(JSON.stringify({ name: 'test' }));
   });
 
-  it('throws when the response is not ok', async () => {
+  it('throws an ApiError with a status-based fallback reason when the response has no body', async () => {
     mockFetch.mockResolvedValue({
       ok: false,
       status: 500,
       headers: new Headers(),
     });
 
-    const { customFetch } = await import('../lib/customFetch');
+    const { customFetch, ApiError } = await import('../lib/customFetch');
     await expect(customFetch('/v1/paths')).rejects.toThrow(
-      'Request failed: 500',
+      'internal server error',
     );
+    try {
+      await customFetch('/v1/paths');
+      throw new Error('expected customFetch to reject');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as InstanceType<typeof ApiError>).status).toBe(500);
+      expect((err as InstanceType<typeof ApiError>).detail).toBeUndefined();
+    }
+  });
+
+  it('surfaces the backend-provided detail message from a JSON error body', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      headers: new Headers(),
+      json: vi.fn().mockResolvedValue({
+        detail:
+          'An error occurred (AccessDenied) when calling the PutObject operation: Access Denied.',
+      }),
+    });
+
+    const { customFetch, ApiError } = await import('../lib/customFetch');
+    await expect(customFetch('/v1/paths')).rejects.toThrow(
+      'An error occurred (AccessDenied) when calling the PutObject operation: Access Denied.',
+    );
+    try {
+      await customFetch('/v1/paths');
+      throw new Error('expected customFetch to reject');
+    } catch (err) {
+      expect((err as InstanceType<typeof ApiError>).detail).toBe(
+        'An error occurred (AccessDenied) when calling the PutObject operation: Access Denied.',
+      );
+    }
   });
 
   it('does not clear the session or flag sessionExpired on a non-401 error', async () => {
@@ -184,7 +217,7 @@ describe('customFetch', () => {
     const { customFetch } = await import('../lib/customFetch');
     const { sessionExpired } = await import('../lib/authSession');
     await expect(customFetch('/v1/paths')).rejects.toThrow(
-      'Request failed: 500',
+      'internal server error',
     );
 
     expect(localStorageStore['user']).toBeDefined();
@@ -203,13 +236,18 @@ describe('customFetch', () => {
 
     const { customFetch } = await import('../lib/customFetch');
     const { sessionExpired } = await import('../lib/authSession');
-    await expect(customFetch('/v1/paths')).rejects.toThrow(
-      'Request failed: 401',
-    );
+    await expect(customFetch('/v1/paths')).rejects.toThrow('not signed in');
 
     expect(localStorageStore['user']).toBeUndefined();
     expect(localStorageStore['session_token']).toBeUndefined();
     expect(sessionExpired.value).toBe(true);
+  });
+
+  it('rejects with a network-error message when fetch itself throws', async () => {
+    mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    const { customFetch } = await import('../lib/customFetch');
+    await expect(customFetch('/v1/paths')).rejects.toThrow('network error');
   });
 
   it('returns undefined data for 204 No Content responses', async () => {

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import {
+  describeError,
+  extractErrorMessage,
+  isApiErrorWithStatus,
+} from '../lib/errors';
+import { ApiError } from '../lib/customFetch';
+
+describe('describeError', () => {
+  it('formats an ApiError with backend detail as "Unable to <action>: <detail>"', () => {
+    const err = new ApiError(
+      500,
+      'An error occurred (AccessDenied) when calling the PutObject operation: Access Denied.',
+    );
+    expect(describeError('create entry', err)).toBe(
+      'Unable to create entry: An error occurred (AccessDenied) when calling the PutObject operation: Access Denied.',
+    );
+  });
+
+  it('falls back to a status-based reason when the backend gives no detail (e.g. an unhandled 500)', () => {
+    const err = new ApiError(500);
+    expect(describeError('create entry', err)).toBe(
+      'Unable to create entry: internal server error',
+    );
+  });
+
+  it('reports a network failure distinctly from a server error', () => {
+    expect(describeError('create entry', new Error('network error'))).toBe(
+      'Unable to create entry: network error',
+    );
+  });
+
+  it('never leaves the reason blank for an unrecognized error shape', () => {
+    expect(describeError('create entry', {})).toBe(
+      'Unable to create entry: unknown error',
+    );
+  });
+});
+
+describe('extractErrorMessage', () => {
+  it('prefers the ApiError detail over the generic message', () => {
+    const err = new ApiError(404, 'Path not found');
+    expect(extractErrorMessage(err)).toBe('Path not found');
+  });
+
+  it('falls back to the ApiError message when there is no detail', () => {
+    const err = new ApiError(404);
+    expect(extractErrorMessage(err)).toBe('not found');
+  });
+});
+
+describe('isApiErrorWithStatus', () => {
+  it('matches an ApiError with the given status', () => {
+    expect(isApiErrorWithStatus(new ApiError(409), 409)).toBe(true);
+  });
+
+  it('does not match an ApiError with a different status', () => {
+    expect(isApiErrorWithStatus(new ApiError(500), 409)).toBe(false);
+  });
+
+  it('does not match a plain Error', () => {
+    expect(isApiErrorWithStatus(new Error('409'), 409)).toBe(false);
+  });
+});

--- a/src/components/EntriesCard.vue
+++ b/src/components/EntriesCard.vue
@@ -72,6 +72,7 @@ import { useQueryClient } from '@tanstack/vue-query';
 
 import { useCreateEntry, getListEntriesQueryKey } from '../generated/apiClient';
 import { useEntries } from '../composables/useEntries';
+import { describeError } from '../lib/errors';
 
 const props = withDefaults(
   defineProps<{
@@ -106,8 +107,8 @@ async function createEntry() {
     await queryClient.invalidateQueries({
       queryKey: getListEntriesQueryKey(props.pathId),
     });
-  } catch {
-    createError.value = 'Failed to create entry. Please try again.';
+  } catch (err: unknown) {
+    createError.value = describeError('create entry', err);
   }
 }
 

--- a/src/components/ExportCard.vue
+++ b/src/components/ExportCard.vue
@@ -91,6 +91,7 @@ import {
   downloadFileFromUrl,
   exportLocalData,
 } from '../utils/export';
+import { describeError, extractErrorMessage } from '../lib/errors';
 
 defineProps<{ paths: PathResponse[] }>();
 
@@ -117,7 +118,7 @@ async function handleDownload(url: string, extension: string) {
       `paths_backup_${todayYYYYMMDD()}.${extension}`,
     );
   } catch (e) {
-    downloadError.value = e instanceof Error ? e.message : String(e);
+    downloadError.value = describeError('download export', e);
   }
 }
 
@@ -137,8 +138,8 @@ async function triggerExport() {
     ).data as ExportJobResponse;
     await pollExport();
   } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    localExportAlertMessage.value = `Remote export failed: ${msg}. Would you like to export your locally cached data instead?`;
+    const reason = extractErrorMessage(e) ?? 'unknown error';
+    localExportAlertMessage.value = `Unable to export: ${reason}. Would you like to export your locally cached data instead?`;
     showLocalExportAlert.value = true;
   }
 }
@@ -165,7 +166,7 @@ function handleLocalExport() {
   try {
     exportLocalData(queryClient, [...selectedForExport.value]);
   } catch (e) {
-    downloadError.value = e instanceof Error ? e.message : String(e);
+    downloadError.value = describeError('export local data', e);
   }
 }
 

--- a/src/components/PathBrowserCard.vue
+++ b/src/components/PathBrowserCard.vue
@@ -97,6 +97,7 @@ import type { PathResponse } from '../generated/types';
 import { isPathHidden, setPathHidden } from '../lib/db';
 import { usePaths } from '../composables/usePaths';
 import { useCreatePath } from '../generated/apiClient';
+import { describeError } from '../lib/errors';
 
 withDefaults(
   defineProps<{
@@ -167,8 +168,8 @@ async function createPath() {
     });
     cancelCreate();
     await refetch();
-  } catch (e) {
-    createError.value = 'Failed to create path. Please try again.';
+  } catch (err: unknown) {
+    createError.value = describeError('create path', err);
   }
 }
 

--- a/src/components/PathDeleteModal.vue
+++ b/src/components/PathDeleteModal.vue
@@ -64,6 +64,7 @@ import { useQueryClient } from '@tanstack/vue-query';
 
 import type { PathResponse } from '../generated/types';
 import { useDeletePath } from '../generated/apiClient';
+import { describeError } from '../lib/errors';
 
 const props = defineProps<{
   isOpen: boolean;
@@ -101,8 +102,8 @@ async function confirmDelete() {
     void queryClient.invalidateQueries({ queryKey: ['v1', 'paths'] });
     emit('deleted');
     emit('dismiss');
-  } catch {
-    errorMessage.value = 'Failed to delete path. Please try again.';
+  } catch (err: unknown) {
+    errorMessage.value = describeError('delete path', err);
   } finally {
     deleting.value = false;
   }

--- a/src/components/PathFormModal.stories.ts
+++ b/src/components/PathFormModal.stories.ts
@@ -112,7 +112,9 @@ export const ShowsAnErrorAndStaysOpenIfCreationFails: Story = {
     await userEvent.click(screen.getByText('Create'));
 
     await expect(
-      await screen.findByText('Failed to create path', { exact: false }),
+      await screen.findByText('Unable to create path: Server error', {
+        exact: false,
+      }),
     ).toBeInTheDocument();
     await expect(args.onDismiss).not.toHaveBeenCalled();
   },

--- a/src/components/PathFormModal.vue
+++ b/src/components/PathFormModal.vue
@@ -81,6 +81,7 @@ import {
   useUpdatePath,
   useUpdatePathVisibility,
 } from '../generated/apiClient';
+import { describeError, isApiErrorWithStatus } from '../lib/errors';
 
 const PATH_SWATCHES = [
   '#5b52f0',
@@ -184,10 +185,9 @@ async function save() {
     emit('saved', saved);
     emit('dismiss');
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
-    errorMessage.value = msg.includes('Request failed: 409')
+    errorMessage.value = isApiErrorWithStatus(err, 409)
       ? 'A path with that name already exists. Please choose a different title.'
-      : `Failed to ${props.path ? 'update' : 'create'} path. Please try again.`;
+      : describeError(props.path ? 'update path' : 'create path', err);
   } finally {
     saving.value = false;
   }

--- a/src/components/PathShareModal.stories.ts
+++ b/src/components/PathShareModal.stories.ts
@@ -180,7 +180,9 @@ export const ShowsErrorWhenInvitationFails: Story = {
     await userEvent.click(inviteButton);
 
     await expect(
-      await screen.findByText('Failed to invite', { exact: false }),
+      await screen.findByText('Unable to invite subscriber: User not found', {
+        exact: false,
+      }),
     ).toBeInTheDocument();
   },
 };

--- a/src/components/PathSubscriptionManager.vue
+++ b/src/components/PathSubscriptionManager.vue
@@ -56,7 +56,7 @@ import {
   getListSubscriptionsQueryKey,
 } from '../generated/apiClient';
 import type { SubscriberResponse } from '../generated/types';
-import { extractErrorMessage } from '../lib/errors';
+import { describeError } from '../lib/errors';
 
 const props = defineProps<{
   pathCode: string;
@@ -94,10 +94,7 @@ async function invite() {
     inviteSuccess.value = 'Invitation sent successfully.';
     inviteEmail.value = '';
   } catch (err: unknown) {
-    const detail = extractErrorMessage(err);
-    inviteError.value = detail
-      ? `Failed to invite: ${detail}`
-      : 'Failed to send invitation. Please try again.';
+    inviteError.value = describeError('invite subscriber', err);
   } finally {
     inviting.value = false;
   }

--- a/src/lib/customFetch.ts
+++ b/src/lib/customFetch.ts
@@ -6,13 +6,65 @@ export interface CustomFetchOptions extends RequestInit {
   onUploadProgress?: (loaded: number, total: number) => void;
 }
 
+const NETWORK_ERROR_MESSAGE = 'network error';
+
+// Sensible copy for known failure classes when the backend response carries
+// no usable detail (e.g. an unhandled exception returning a bare 500) — this
+// is what shows up after "Unable to <action>: " on a mobile-first UI, so it
+// must never be a raw status code.
+function fallbackReason(status: number): string {
+  if (status === 401) return 'not signed in';
+  if (status === 403) return 'access denied';
+  if (status === 404) return 'not found';
+  if (status === 409) return 'conflicting change';
+  if (status >= 500) return 'internal server error';
+  return `request failed (${status})`;
+}
+
+/** Pull a `detail`/`message`/`error` string out of a parsed JSON error body, if there is one. */
+function detailFromBody(body: unknown): string | undefined {
+  if (!body || typeof body !== 'object') return undefined;
+  const b = body as Record<string, unknown>;
+  if (typeof b.detail === 'string') return b.detail;
+  if (Array.isArray(b.detail)) {
+    // FastAPI 422 validation errors: detail is a list of {loc, msg, type}.
+    const msgs = b.detail
+      .map((d) =>
+        d && typeof d === 'object'
+          ? (d as Record<string, unknown>).msg
+          : undefined,
+      )
+      .filter((m): m is string => typeof m === 'string');
+    if (msgs.length > 0) return msgs.join('; ');
+  }
+  if (typeof b.message === 'string') return b.message;
+  if (typeof b.error === 'string') return b.error;
+  return undefined;
+}
+
+async function detailFromResponse(
+  response: Response,
+): Promise<string | undefined> {
+  if (typeof response.json !== 'function') return undefined;
+  try {
+    return detailFromBody(await response.json());
+  } catch {
+    // Not JSON (or empty body) — e.g. a plain-text 500 from an unhandled
+    // exception with no custom error handler.
+    return undefined;
+  }
+}
+
 export class ApiError extends Error {
   status: number;
+  /** Backend-provided detail text, when the response body had one. */
+  detail?: string;
 
-  constructor(status: number) {
-    super(`Request failed: ${status}`);
+  constructor(status: number, detail?: string) {
+    super(detail ?? fallbackReason(status));
     this.name = 'ApiError';
     this.status = status;
+    this.detail = detail;
   }
 }
 
@@ -47,14 +99,20 @@ export const customFetch = async <T>(
     return uploadWithProgress<T>(`${baseUrl}${url}`, options, headers);
   }
 
-  const response = await fetch(`${baseUrl}${url}`, {
-    ...options,
-    credentials: 'include',
-    headers,
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${baseUrl}${url}`, {
+      ...options,
+      credentials: 'include',
+      headers,
+    });
+  } catch {
+    throw new Error(NETWORK_ERROR_MESSAGE);
+  }
   if (!response.ok) {
+    const detail = await detailFromResponse(response);
     if (response.status === 401) clearSession();
-    throw new ApiError(response.status);
+    throw new ApiError(response.status, detail);
   }
   const data = response.status === 204 ? undefined : await response.json();
   return { data, status: response.status, headers: response.headers } as T;
@@ -75,11 +133,17 @@ function uploadWithProgress<T>(
     xhr.upload.onprogress = (e) => {
       if (e.lengthComputable) options.onUploadProgress?.(e.loaded, e.total);
     };
-    xhr.onerror = () => reject(new Error('Request failed: network error'));
+    xhr.onerror = () => reject(new Error(NETWORK_ERROR_MESSAGE));
     xhr.onload = () => {
       if (xhr.status < 200 || xhr.status >= 300) {
         if (xhr.status === 401) clearSession();
-        reject(new ApiError(xhr.status));
+        let detail: string | undefined;
+        try {
+          detail = detailFromBody(JSON.parse(xhr.responseText));
+        } catch {
+          detail = undefined;
+        }
+        reject(new ApiError(xhr.status, detail));
         return;
       }
       const data =

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,5 +1,8 @@
+import { ApiError } from './customFetch';
+
 /** Extract a human-readable message from an unknown caught error. */
 export function extractErrorMessage(err: unknown): string | undefined {
+  if (err instanceof ApiError) return err.detail ?? err.message;
   if (typeof err === 'string') return err;
   if (!err || typeof err !== 'object') return undefined;
   const e = err as Record<string, unknown>;
@@ -12,4 +15,20 @@ export function extractErrorMessage(err: unknown): string | undefined {
   }
   if (typeof e.message === 'string') return e.message;
   return undefined;
+}
+
+/**
+ * Format a caught error for display on a known failure path, as
+ * "Unable to <action>: <reason>" — e.g. "Unable to create entry: internal
+ * server error". Every user-facing error on a mobile-first UI should say
+ * what failed and why, never a bare "please try again".
+ */
+export function describeError(action: string, err: unknown): string {
+  const reason = extractErrorMessage(err) ?? 'unknown error';
+  return `Unable to ${action}: ${reason}`;
+}
+
+/** True when `err` is an ApiError for the given HTTP status code. */
+export function isApiErrorWithStatus(err: unknown, status: number): boolean {
+  return err instanceof ApiError && err.status === status;
 }

--- a/src/pages/auth.callback.vue
+++ b/src/pages/auth.callback.vue
@@ -26,6 +26,7 @@ import { useRouter, useRoute } from 'vue-router';
 
 import { useAuthCallback } from '../generated/apiClient';
 import type { OAuthCallbackResponse } from '../generated/types';
+import { describeError } from '../lib/errors';
 
 const router = useRouter();
 const route = useRoute();
@@ -40,7 +41,7 @@ onMounted(async () => {
   const state = Array.isArray(rawState) ? rawState[0] : rawState;
 
   if (!code || !state) {
-    error.value = 'Missing code or state parameter.';
+    error.value = 'Unable to complete login: missing code or state parameter';
     return;
   }
 
@@ -55,8 +56,8 @@ onMounted(async () => {
       localStorage.setItem('session_token', token);
       localStorage.setItem('user', JSON.stringify(safeData));
     }
-  } catch {
-    error.value = 'Login failed. Please try again.';
+  } catch (err: unknown) {
+    error.value = describeError('complete login', err);
   } finally {
     router.push('/');
   }

--- a/src/pages/entry.[pathId].[entryId].edit.vue
+++ b/src/pages/entry.[pathId].[entryId].edit.vue
@@ -186,7 +186,7 @@ import {
 import { usePaths } from '../composables/usePaths';
 import { useLocalDraft } from '../composables/useLocalDraft';
 import { pickImages } from '../composables/useImagePicker';
-import { extractErrorMessage } from '../lib/errors';
+import { describeError, isApiErrorWithStatus } from '../lib/errors';
 import MarkdownContent from '../components/MarkdownContent.vue';
 import SavingOverlay from '../components/SavingOverlay.vue';
 import { useMarkdownEditor } from '../composables/useMarkdownEditor';
@@ -309,15 +309,11 @@ async function submit() {
     await clearDraft();
     router.push(`/entry/${pathId}/${entryId}`);
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes('409')) {
+    if (isApiErrorWithStatus(err, 409)) {
       conflictError.value =
         'A newer version of this entry exists. Go back and reopen it to edit the latest version.';
     } else {
-      const detail = extractErrorMessage(err);
-      error.value = detail
-        ? `Failed to save entry: ${detail}`
-        : 'Failed to save entry. Please try again.';
+      error.value = describeError('save entry', err);
     }
   } finally {
     saving.value = false;

--- a/src/pages/entry.[pathId].[entryId].vue
+++ b/src/pages/entry.[pathId].[entryId].vue
@@ -104,7 +104,7 @@ import { usePaths } from '../composables/usePaths';
 import { usePathVisibility } from '../composables/usePathVisibility';
 import { useMultiPathEntries } from '../composables/useMultiPathEntries';
 import { useOnThisDay } from '../composables/useOnThisDay';
-import { extractErrorMessage } from '../lib/errors';
+import { describeError } from '../lib/errors';
 import MarkdownContent from '../components/MarkdownContent.vue';
 import EntryImage from '../components/EntryImage.vue';
 import { referencedImageFilenames } from '../utils/markdown';
@@ -230,7 +230,7 @@ async function performDelete() {
     });
     router.back();
   } catch (err: unknown) {
-    deleteError.value = extractErrorMessage(err) ?? 'Failed to delete entry.';
+    deleteError.value = describeError('delete entry', err);
   }
 }
 </script>

--- a/src/pages/entry.new.vue
+++ b/src/pages/entry.new.vue
@@ -156,7 +156,7 @@ import { useCreateEntry } from '../generated/apiClient';
 import { usePaths } from '../composables/usePaths';
 import { useLocalDraft } from '../composables/useLocalDraft';
 import { pickImages } from '../composables/useImagePicker';
-import { extractErrorMessage } from '../lib/errors';
+import { describeError } from '../lib/errors';
 import MarkdownContent from '../components/MarkdownContent.vue';
 import SavingOverlay from '../components/SavingOverlay.vue';
 import { useMarkdownEditor } from '../composables/useMarkdownEditor';
@@ -277,10 +277,7 @@ async function submit() {
     await clearDraft();
     router.back();
   } catch (err: unknown) {
-    const detail = extractErrorMessage(err);
-    error.value = detail
-      ? `Failed to create entry: ${detail}`
-      : 'Failed to create entry. Please try again.';
+    error.value = describeError('create entry', err);
   }
 }
 </script>

--- a/src/pages/entryEditor.edit.stories.ts
+++ b/src/pages/entryEditor.edit.stories.ts
@@ -146,7 +146,7 @@ export const SavingSucceeds: Story = {
       expect(canvas.queryByText('Saving…')).not.toBeInTheDocument(),
     );
     await expect(
-      canvas.queryByText('Failed to save entry', { exact: false }),
+      canvas.queryByText('Unable to save entry', { exact: false }),
     ).not.toBeInTheDocument();
   },
 };
@@ -218,7 +218,9 @@ export const ServerErrorShowsInlineMessage: Story = {
     await userEvent.click(canvas.getByText('Save'));
 
     await expect(
-      await canvas.findByText('Failed to save entry', { exact: false }),
+      await canvas.findByText('Unable to save entry: Internal Server Error', {
+        exact: false,
+      }),
     ).toBeInTheDocument();
     await expect(canvas.getByText('Save')).not.toBeDisabled();
   },

--- a/src/pages/entryEditor.new.stories.ts
+++ b/src/pages/entryEditor.new.stories.ts
@@ -204,7 +204,9 @@ export const ServerErrorShowsInlineMessage: Story = {
     await userEvent.click(canvas.getByText('Save'));
 
     await expect(
-      await canvas.findByText('Failed to create entry', { exact: false }),
+      await canvas.findByText('Unable to create entry: Internal Server Error', {
+        exact: false,
+      }),
     ).toBeInTheDocument();
     await expect(canvas.getByText('Save')).not.toBeDisabled();
   },

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -74,6 +74,7 @@ import type {
   OAuthLoginResponse,
 } from '../generated/types';
 import { authLogin } from '../generated/apiClient';
+import { describeError } from '../lib/errors';
 import { usePaths } from '../composables/usePaths';
 import { usePathVisibility } from '../composables/usePathVisibility';
 import { useMultiPathEntries } from '../composables/useMultiPathEntries';
@@ -126,11 +127,11 @@ async function loginWithGoogle() {
     if (loginData?.authorization_url) {
       window.location.href = loginData.authorization_url;
     } else {
-      loginError.value = 'Could not start login. Please try again.';
+      loginError.value = 'Unable to sign in: no authorization URL returned';
       loggingIn.value = false;
     }
-  } catch {
-    loginError.value = 'Could not start login. Please try again.';
+  } catch (err: unknown) {
+    loginError.value = describeError('sign in', err);
     loggingIn.value = false;
   }
 }


### PR DESCRIPTION
customFetch discarded the response body on failure, so any backend detail
(FastAPI's {"detail": ...}, or a plain 500 from an unhandled exception like
the S3 AccessDenied crash on entry creation) was lost and replaced with a
bare "Request failed: <status>". ApiError now carries that detail when the
backend sends one, and falls back to a status-appropriate reason (e.g.
"internal server error" for a bare 5xx) when it doesn't.

Every known failure path (create/delete/save entry, create/update/delete
path, invite subscriber, export, sign in) now reports through a shared
describeError() helper using the "Unable to <action>: <reason>" pattern
instead of ad hoc "Failed to ..." strings, so mobile users always see what
failed and why.