### PR TITLE
Add lightbox image viewer for entry photos

### DIFF
--- a/src/__tests__/imageDownload.test.ts
+++ b/src/__tests__/imageDownload.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { kebabCase } from '../utils/text';
+import { buildImageDownloadFilename } from '../utils/imageDownload';
+
+describe('kebabCase', () => {
+  it('lowercases and hyphenates words', () => {
+    expect(kebabCase('Sunrise over the ridge')).toBe('sunrise-over-the-ridge');
+  });
+
+  it('strips punctuation and collapses runs of separators', () => {
+    expect(kebabCase("Mom's 40th!! -- birthday??")).toBe('mom-s-40th-birthday');
+  });
+
+  it('drops non-ascii characters entirely', () => {
+    expect(kebabCase('Café au lait')).toBe('caf-au-lait');
+  });
+
+  it('trims leading/trailing separators', () => {
+    expect(kebabCase('  --hello world--  ')).toBe('hello-world');
+  });
+
+  it('truncates long input at a word boundary', () => {
+    const long = 'one two three four five six seven eight nine ten eleven';
+    const result = kebabCase(long, 20);
+    expect(result.length).toBeLessThanOrEqual(20);
+    expect(result).not.toMatch(/-$/);
+    expect(result).toBe('one-two-three-four');
+  });
+
+  it('returns empty string for input with nothing kebab-able', () => {
+    expect(kebabCase('!!!')).toBe('');
+  });
+});
+
+describe('buildImageDownloadFilename', () => {
+  it('combines the entry date and a slug of the caption', () => {
+    const name = buildImageDownloadFilename('2024-01-01', {
+      filename: 'IMG_1234.JPG',
+      caption: 'Sunrise over the ridge',
+      content_type: 'image/jpeg',
+    });
+    expect(name).toBe('2024-01-01-sunrise-over-the-ridge.jpg');
+  });
+
+  it('falls back to just the date when there is no caption', () => {
+    const name = buildImageDownloadFilename('2024-01-01', {
+      filename: 'photo.png',
+      caption: null,
+      content_type: 'image/png',
+    });
+    expect(name).toBe('2024-01-01.png');
+  });
+
+  it('prefers the extension from the filename over the content type', () => {
+    const name = buildImageDownloadFilename('2024-01-01', {
+      filename: 'photo.jpeg',
+      caption: null,
+      content_type: 'image/webp',
+    });
+    expect(name).toBe('2024-01-01.jpeg');
+  });
+
+  it('falls back to the content type extension when the filename has none', () => {
+    const name = buildImageDownloadFilename('2024-01-01', {
+      filename: 'photo',
+      caption: null,
+      content_type: 'image/webp',
+    });
+    expect(name).toBe('2024-01-01.webp');
+  });
+
+  it('defaults to jpg when neither filename nor content type give an extension', () => {
+    const name = buildImageDownloadFilename('2024-01-01', {
+      filename: 'photo',
+      caption: null,
+      content_type: null,
+    });
+    expect(name).toBe('2024-01-01.jpg');
+  });
+});

--- a/src/components/DayBrowser.vue
+++ b/src/components/DayBrowser.vue
@@ -100,17 +100,26 @@
           </router-link>
           <div v-if="pe.images.length > 0" class="db-entry-photos">
             <EntryImage
-              v-for="img in pe.images.slice(0, 3)"
+              v-for="(img, idx) in pe.images.slice(0, 3)"
               :key="img.id"
               :image-id="img.id"
               :alt="img.filename"
               class="db-entry-photo"
+              @open="openLightbox(pe.images, idx)"
             />
           </div>
         </div>
       </template>
       <p v-else class="db-day-empty">No entries yet.</p>
     </div>
+
+    <ImageLightbox
+      :is-open="lightbox !== null"
+      :images="lightbox?.images ?? []"
+      :start-index="lightbox?.index ?? 0"
+      :day="selectedDate"
+      @dismiss="lightbox = null"
+    />
   </div>
 </template>
 
@@ -123,6 +132,7 @@ import type { PathEntries } from '../composables/useMultiPathEntries';
 import { useOnThisDay } from '../composables/useOnThisDay';
 import { toLocalISODate } from '../utils/date';
 import EntryImage from './EntryImage.vue';
+import ImageLightbox from './ImageLightbox.vue';
 
 const props = defineProps<{
   visiblePaths: PathResponse[];
@@ -300,6 +310,11 @@ const selectedEntries = computed<DayPathEntry[]>(() => {
   }
   return result;
 });
+
+const lightbox = ref<{ images: ImageResponse[]; index: number } | null>(null);
+function openLightbox(images: ImageResponse[], index: number) {
+  lightbox.value = { images, index };
+}
 
 defineExpose({ selectedDate });
 </script>

--- a/src/components/EntryImage.stories.ts
+++ b/src/components/EntryImage.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/vue3';
-import { expect, waitFor, within } from 'storybook/test';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import { http, HttpResponse, delay } from 'msw';
 
 import EntryImage from './EntryImage.vue';
@@ -11,6 +11,7 @@ const meta: Meta<typeof EntryImage> = {
   args: {
     imageId: 'img-1',
     alt: 'A photo from the entry',
+    onOpen: fn(),
   },
 };
 
@@ -32,17 +33,16 @@ export const Loaded: Story = {
       ],
     },
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
     const img = await canvas.findByAltText('A photo from the entry');
     await expect(img).toHaveAttribute(
       'src',
       imageDownloadResponseFixture.thumbnail_url,
     );
-    await expect(img.closest('a')).toHaveAttribute(
-      'href',
-      imageDownloadResponseFixture.image_url,
-    );
+
+    await userEvent.click(img.closest('button')!);
+    await expect(args.onOpen).toHaveBeenCalled();
   },
 };
 
@@ -59,9 +59,9 @@ export const Loading: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(
-      await canvas.findByLabelText('Loading image'),
-    ).toBeInTheDocument();
+    const placeholder = await canvas.findByLabelText('Loading image');
+    await expect(placeholder).toBeInTheDocument();
+    await expect(placeholder.closest('button')).toBeDisabled();
   },
 };
 
@@ -83,5 +83,6 @@ export const Errored: Story = {
       expect(el).toBeInTheDocument();
     });
     expect(canvasElement.querySelector('img')).not.toBeInTheDocument();
+    expect(canvasElement.querySelector('button')).toBeDisabled();
   },
 };

--- a/src/components/EntryImage.vue
+++ b/src/components/EntryImage.vue
@@ -1,10 +1,10 @@
 <template>
-  <a
-    :href="imageUrl || undefined"
-    target="_blank"
-    rel="noopener noreferrer"
+  <button
+    type="button"
     class="entry-image-link"
-    :aria-label="alt || 'View image'"
+    :aria-label="alt ? `View ${alt}` : 'View image'"
+    :disabled="!imageUrl || loadFailed"
+    @click="emit('open')"
   >
     <img
       v-if="imageUrl && !loadFailed"
@@ -27,7 +27,7 @@
       :aria-label="errorMessage || 'Failed to load image'"
       >⚠️</span
     >
-  </a>
+  </button>
 </template>
 
 <script setup lang="ts">
@@ -39,6 +39,10 @@ import { extractErrorMessage } from '../lib/errors';
 const props = defineProps<{
   imageId: string;
   alt?: string;
+}>();
+
+const emit = defineEmits<{
+  open: [];
 }>();
 
 const { data, isLoading, error } = useGetImageDownloadUrl(
@@ -66,7 +70,14 @@ const errorMessage = computed(() => extractErrorMessage(error.value));
 <style scoped>
 .entry-image-link {
   display: inline-block;
-  text-decoration: none;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.entry-image-link:disabled {
+  cursor: default;
 }
 
 .entry-image-thumb {

--- a/src/components/ImageLightbox.stories.ts
+++ b/src/components/ImageLightbox.stories.ts
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import { expect, fn, screen, userEvent, waitFor } from 'storybook/test';
+
+import ImageLightbox from './ImageLightbox.vue';
+import { imageResponseFixture } from '../generated/fixtures';
+import { modalRender } from '../../.storybook/modalRender';
+
+// ion-modal teleports its content to document.body, so these stories query
+// the global `screen` (bound to document.body) rather than canvasElement.
+
+const imageA = {
+  ...imageResponseFixture,
+  id: 'img-a',
+  filename: 'morning-walk.jpg',
+  caption: 'Sunrise over the ridge',
+};
+const imageB = {
+  ...imageResponseFixture,
+  id: 'img-b',
+  filename: 'lunch.jpg',
+  caption: 'Packed lunch at the summit',
+};
+
+const meta: Meta<typeof ImageLightbox> = {
+  title: 'Components/ImageLightbox',
+  component: ImageLightbox,
+  render: modalRender(ImageLightbox),
+  args: {
+    isOpen: true,
+    images: [imageA],
+    startIndex: 0,
+    day: '2024-01-01',
+    onDismiss: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ImageLightbox>;
+
+export const Default: Story = {
+  play: async () => {
+    await expect(await screen.findByText(imageA.caption)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText('Download full resolution')).not.toBeDisabled(),
+    );
+    // A single image gets no prev/next controls.
+    expect(screen.queryByLabelText('Previous image')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Next image')).not.toBeInTheDocument();
+  },
+};
+
+export const NoCaption: Story = {
+  args: {
+    images: [{ ...imageA, caption: null }],
+  },
+  play: async () => {
+    await waitFor(() =>
+      expect(screen.getByText('Download full resolution')).not.toBeDisabled(),
+    );
+    expect(screen.queryByText(imageA.caption)).not.toBeInTheDocument();
+  },
+};
+
+export const MultipleImagesNavigate: Story = {
+  args: {
+    images: [imageA, imageB],
+    startIndex: 0,
+  },
+  play: async () => {
+    await expect(await screen.findByText('1 / 2')).toBeInTheDocument();
+    await expect(screen.getByText(imageA.caption)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText('Next image'));
+    await expect(await screen.findByText('2 / 2')).toBeInTheDocument();
+    await expect(screen.getByText(imageB.caption)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText('Previous image'));
+    await expect(await screen.findByText('1 / 2')).toBeInTheDocument();
+    await expect(screen.getByText(imageA.caption)).toBeInTheDocument();
+  },
+};
+
+export const CloseDismisses: Story = {
+  play: async ({ args }) => {
+    await userEvent.click(await screen.findByLabelText('Close'));
+    await expect(args.onDismiss).toHaveBeenCalled();
+  },
+};

--- a/src/components/ImageLightbox.vue
+++ b/src/components/ImageLightbox.vue
@@ -1,0 +1,283 @@
+<template>
+  <ion-modal
+    class="image-lightbox-modal"
+    :is-open="isOpen"
+    :aria-label="
+      currentImage ? `Viewing ${currentImage.filename}` : 'Image viewer'
+    "
+    @didDismiss="onDismiss"
+  >
+    <div v-if="currentImage" class="lightbox df-ui">
+      <div class="lightbox-topbar">
+        <span v-if="images.length > 1" class="lightbox-counter">
+          {{ currentIndex + 1 }} / {{ images.length }}
+        </span>
+        <button
+          type="button"
+          class="lightbox-icon-btn"
+          aria-label="Close"
+          @click="onDismiss"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div class="lightbox-image-wrap">
+        <button
+          v-if="images.length > 1"
+          type="button"
+          class="lightbox-nav lightbox-nav--prev"
+          aria-label="Previous image"
+          @click="prev"
+        >
+          ‹
+        </button>
+
+        <span
+          v-if="isLoading"
+          class="lightbox-placeholder"
+          aria-label="Loading image"
+          >⏳</span
+        >
+        <span
+          v-else-if="!fullImageUrl || loadFailed"
+          class="lightbox-placeholder lightbox-placeholder--error"
+          :aria-label="errorMessage || 'Failed to load image'"
+          >⚠️</span
+        >
+        <img
+          v-else
+          :src="fullImageUrl"
+          :alt="currentImage.filename"
+          class="lightbox-image"
+          @error="loadFailed = true"
+        />
+
+        <button
+          v-if="images.length > 1"
+          type="button"
+          class="lightbox-nav lightbox-nav--next"
+          aria-label="Next image"
+          @click="next"
+        >
+          ›
+        </button>
+      </div>
+
+      <p v-if="currentImage.caption" class="lightbox-caption">
+        {{ currentImage.caption }}
+      </p>
+
+      <div class="lightbox-actions">
+        <button
+          type="button"
+          class="lightbox-download-btn"
+          :disabled="!fullImageUrl || downloading"
+          @click="handleDownload"
+        >
+          {{ downloading ? 'Downloading…' : 'Download full resolution' }}
+        </button>
+        <p v-if="downloadError" class="lightbox-error">{{ downloadError }}</p>
+      </div>
+    </div>
+  </ion-modal>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { IonModal } from '@ionic/vue';
+
+import { useGetImageDownloadUrl } from '../generated/apiClient';
+import type { ImageDownloadResponse, ImageResponse } from '../generated/types';
+import { extractErrorMessage } from '../lib/errors';
+import { downloadFileFromUrl } from '../utils/export';
+import { buildImageDownloadFilename } from '../utils/imageDownload';
+
+const props = defineProps<{
+  isOpen: boolean;
+  images: ImageResponse[];
+  startIndex: number;
+  day: string;
+}>();
+
+const emit = defineEmits<{
+  dismiss: [];
+}>();
+
+const currentIndex = ref(props.startIndex);
+const loadFailed = ref(false);
+
+watch(
+  () => [props.isOpen, props.startIndex] as const,
+  ([open, startIndex]) => {
+    if (open) {
+      currentIndex.value = startIndex;
+      loadFailed.value = false;
+    }
+  },
+);
+watch(currentIndex, () => (loadFailed.value = false));
+
+const currentImage = computed<ImageResponse | undefined>(
+  () => props.images[currentIndex.value],
+);
+
+const { data, isLoading, error } = useGetImageDownloadUrl(
+  computed(() => currentImage.value?.id ?? ''),
+);
+
+const fullImageUrl = computed(
+  () =>
+    (data.value?.data as ImageDownloadResponse | undefined)?.image_url ?? null,
+);
+const errorMessage = computed(() => extractErrorMessage(error.value));
+
+function prev() {
+  currentIndex.value =
+    (currentIndex.value - 1 + props.images.length) % props.images.length;
+}
+function next() {
+  currentIndex.value = (currentIndex.value + 1) % props.images.length;
+}
+
+function onDismiss() {
+  emit('dismiss');
+}
+
+const downloading = ref(false);
+const downloadError = ref('');
+
+async function handleDownload() {
+  const url = fullImageUrl.value;
+  const image = currentImage.value;
+  if (!url || !image) return;
+  downloading.value = true;
+  downloadError.value = '';
+  try {
+    await downloadFileFromUrl(
+      url,
+      buildImageDownloadFilename(props.day, image),
+    );
+  } catch (err: unknown) {
+    downloadError.value =
+      extractErrorMessage(err) ?? 'Failed to download image.';
+  } finally {
+    downloading.value = false;
+  }
+}
+</script>
+
+<style scoped>
+.image-lightbox-modal {
+  --background: rgba(0, 0, 0, 0.92);
+  --box-shadow: none;
+}
+
+.lightbox {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  color: #fff;
+}
+
+.lightbox-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+}
+
+.lightbox-counter {
+  margin-right: auto;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.lightbox-icon-btn {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.4rem;
+  line-height: 1;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+.lightbox-image-wrap {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 0;
+  padding: 0 1rem;
+}
+
+.lightbox-image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+.lightbox-placeholder {
+  font-size: 2.5rem;
+}
+
+.lightbox-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.4);
+  border: none;
+  color: #fff;
+  font-size: 2rem;
+  line-height: 1;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.lightbox-nav--prev {
+  left: 0.5rem;
+}
+
+.lightbox-nav--next {
+  right: 0.5rem;
+}
+
+.lightbox-caption {
+  margin: 0;
+  padding: 0.75rem 1.25rem 0;
+  text-align: center;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.lightbox-actions {
+  padding: 0.75rem 1.25rem 1.25rem;
+  text-align: center;
+}
+
+.lightbox-download-btn {
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  color: #fff;
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.lightbox-download-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.lightbox-error {
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  color: #ff8a8a;
+}
+</style>

--- a/src/components/PathBrowser.vue
+++ b/src/components/PathBrowser.vue
@@ -44,11 +44,12 @@
           </router-link>
           <div v-if="(entry.images?.length ?? 0) > 0" class="pb-entry-photos">
             <EntryImage
-              v-for="img in entry.images!.slice(0, 3)"
+              v-for="(img, idx) in entry.images!.slice(0, 3)"
               :key="img.id"
               :image-id="img.id"
               :alt="img.filename"
               class="pb-entry-photo"
+              @open="openLightbox(entry.images!, idx, entry.day)"
             />
           </div>
         </div>
@@ -58,16 +59,25 @@
       </template>
       <p v-else class="pb-empty">No entries yet.</p>
     </div>
+
+    <ImageLightbox
+      :is-open="lightbox !== null"
+      :images="lightbox?.images ?? []"
+      :start-index="lightbox?.index ?? 0"
+      :day="lightbox?.day ?? ''"
+      @dismiss="lightbox = null"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { IonSpinner } from '@ionic/vue';
 
-import type { PathResponse } from '../generated/types';
+import type { ImageResponse, PathResponse } from '../generated/types';
 import type { EntryWithContent } from '../composables/useMultiPathEntries';
 import EntryImage from './EntryImage.vue';
+import ImageLightbox from './ImageLightbox.vue';
 
 const props = defineProps<{
   paths: PathResponse[];
@@ -100,6 +110,15 @@ const sortedEntries = computed(() =>
 const visibleEntries = computed(() =>
   sortedEntries.value.filter((entry) => entry.inWindow),
 );
+
+const lightbox = ref<{
+  images: ImageResponse[];
+  index: number;
+  day: string;
+} | null>(null);
+function openLightbox(images: ImageResponse[], index: number, day: string) {
+  lightbox.value = { images, index, day };
+}
 
 function dateLabel(day: string): string {
   return new Date(day + 'T00:00:00').toLocaleDateString(undefined, {

--- a/src/pages/entry.[pathId].[entryId].vue
+++ b/src/pages/entry.[pathId].[entryId].vue
@@ -53,10 +53,11 @@
           </p>
           <div class="entry-images">
             <EntryImage
-              v-for="img in unreferencedImages"
+              v-for="(img, idx) in unreferencedImages"
               :key="img.id"
               :image-id="img.id"
               :alt="img.filename"
+              @open="openLightbox(idx)"
             />
           </div>
         </template>
@@ -86,6 +87,14 @@
       :buttons="deleteAlertButtons"
       @didDismiss="showDeleteAlert = false"
     />
+
+    <ImageLightbox
+      :is-open="lightboxIndex !== null"
+      :images="unreferencedImages"
+      :start-index="lightboxIndex ?? 0"
+      :day="entryDay"
+      @dismiss="lightboxIndex = null"
+    />
   </ion-page>
 </template>
 
@@ -107,6 +116,7 @@ import { useOnThisDay } from '../composables/useOnThisDay';
 import { extractErrorMessage } from '../lib/errors';
 import MarkdownContent from '../components/MarkdownContent.vue';
 import EntryImage from '../components/EntryImage.vue';
+import ImageLightbox from '../components/ImageLightbox.vue';
 import { referencedImageFilenames } from '../utils/markdown';
 import type {
   EntryContentResponse,
@@ -172,6 +182,11 @@ const referencedFilenames = computed<Set<string>>(() =>
 const unreferencedImages = computed(() =>
   images.value.filter((img) => !referencedFilenames.value.has(img.filename)),
 );
+
+const lightboxIndex = ref<number | null>(null);
+function openLightbox(index: number) {
+  lightboxIndex.value = index;
+}
 
 // "On this day" across every visible path, for *this entry's* date.
 const visiblePathIds = computed(() => visiblePaths.value.map((p) => p.path_id));

--- a/src/utils/imageDownload.ts
+++ b/src/utils/imageDownload.ts
@@ -1,0 +1,39 @@
+import { kebabCase } from './text';
+
+type DownloadableImage = {
+  filename: string;
+  caption: string | null;
+  content_type: string | null;
+};
+
+function extensionFromFilename(filename: string): string | null {
+  const match = /\.([a-zA-Z0-9]+)$/.exec(filename);
+  return match?.[1] ? match[1].toLowerCase() : null;
+}
+
+function extensionFromContentType(contentType: string | null): string | null {
+  const subtype = contentType?.split('/')[1];
+  if (!subtype) return null;
+  return subtype.toLowerCase() === 'jpeg' ? 'jpg' : subtype.toLowerCase();
+}
+
+/**
+ * Builds a download filename for a full-resolution image: the entry's date
+ * plus a kebab-cased slug of the caption (when there is one), keeping the
+ * image's original extension.
+ */
+export function buildImageDownloadFilename(
+  day: string,
+  image: DownloadableImage,
+): string {
+  const ext =
+    extensionFromFilename(image.filename) ??
+    extensionFromContentType(image.content_type) ??
+    'jpg';
+  const slug = image.caption ? kebabCase(image.caption) : '';
+  const base =
+    [day, slug].filter(Boolean).join('-') ||
+    image.filename.replace(/\.[^./]+$/, '') ||
+    'image';
+  return `${base}.${ext}`;
+}

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -1,0 +1,18 @@
+/**
+ * Aggressively converts arbitrary text into a kebab-case slug: lowercased,
+ * ASCII alphanumerics only, hyphen-separated, truncated to a sensible length
+ * without cutting a word in half.
+ */
+export function kebabCase(input: string, maxLength = 60): string {
+  const full = input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  if (full.length <= maxLength) return full;
+
+  const truncated = full.slice(0, maxLength);
+  const lastHyphen = truncated.lastIndexOf('-');
+  const trimmed = lastHyphen > 0 ? truncated.slice(0, lastHyphen) : truncated;
+  return trimmed.replace(/-+$/, '');
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,19 @@ export default defineConfig({
       {
         extends: true,
         plugins: [storybookTest({ configDir: '.storybook' })],
+        // Pre-bundle these so Vite doesn't discover them mid-run and trigger
+        // the dep-optimizer race described above — that reload doesn't just
+        // risk the "Failed to fetch dynamically imported module" rejection,
+        // it can also corrupt in-flight router state (e.g. App.stories.ts
+        // failing with "Cannot read properties of undefined (reading
+        // 'matched')") since the reload lands mid-test rather than between
+        // tests.
+        optimizeDeps: {
+          include: [
+            '@tanstack/query-persist-client-core',
+            'vue-router/auto-routes',
+          ],
+        },
         test: {
           name: 'storybook',
           // GitHub's standard runners (4 vCPU/16GB, further shared with the


### PR DESCRIPTION
Tapping a thumbnail now opens the full-resolution image in an
in-app modal with caption, close, prev/next (when an entry has
several images), and a download button that names the file from
the entry's date plus a kebab-cased slug of the caption.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dfjx9VnwsVP9dTkJH5T4a1