### PR TITLE
Hide formatting toolbar in preview and flip toggle to "Write"

### DIFF
--- a/src/pages/entry.[pathId].[entryId].edit.vue
+++ b/src/pages/entry.[pathId].[entryId].edit.vue
@@ -20,56 +20,31 @@
         </div>
 
         <div class="editor-toolbar">
-          <button
-            type="button"
-            :disabled="contentTab === 'preview'"
-            @click="wrapSelection('**')"
-          >
-            <strong>B</strong>
-          </button>
-          <button
-            type="button"
-            :disabled="contentTab === 'preview'"
-            @click="wrapSelection('*')"
-          >
-            <em>I</em>
-          </button>
-          <button
-            type="button"
-            :disabled="contentTab === 'preview'"
-            @click="prefixLine('# ')"
-          >
-            H1
-          </button>
-          <button
-            type="button"
-            :disabled="contentTab === 'preview'"
-            @click="prefixLine('## ')"
-          >
-            H2
-          </button>
-          <button
-            type="button"
-            :disabled="contentTab === 'preview'"
-            @click="prefixLine('- ')"
-          >
-            • List
-          </button>
-          <button
-            type="button"
-            :disabled="contentTab === 'preview'"
-            aria-label="Insert link"
-            @click="wrapSelection('[', '](url)')"
-          >
-            🔗
-          </button>
+          <template v-if="contentTab === 'write'">
+            <button type="button" @click="wrapSelection('**')">
+              <strong>B</strong>
+            </button>
+            <button type="button" @click="wrapSelection('*')">
+              <em>I</em>
+            </button>
+            <button type="button" @click="prefixLine('# ')">H1</button>
+            <button type="button" @click="prefixLine('## ')">H2</button>
+            <button type="button" @click="prefixLine('- ')">• List</button>
+            <button
+              type="button"
+              aria-label="Insert link"
+              @click="wrapSelection('[', '](url)')"
+            >
+              🔗
+            </button>
+          </template>
           <button
             type="button"
             class="preview-toggle"
             :class="{ 'preview-toggle--active': contentTab === 'preview' }"
             @click="contentTab = contentTab === 'preview' ? 'write' : 'preview'"
           >
-            Preview
+            {{ contentTab === 'preview' ? 'Write' : 'Preview' }}
           </button>
         </div>
 

--- a/src/pages/entry.new.vue
+++ b/src/pages/entry.new.vue
@@ -41,56 +41,31 @@
         </div>
 
         <div class="editor-toolbar">
-          <button
-            type="button"
-            :disabled="contentTab === 'preview'"
-            @click="wrapSelection('**')"
-          >
-            <strong>B</strong>
-          </button>
-          <button
-            type="button"
-            :disabled="contentTab === 'preview'"
-            @click="wrapSelection('*')"
-          >
-            <em>I</em>
-          </button>
-          <button
-            type="button"
-            :disabled="contentTab === 'preview'"
-            @click="prefixLine('# ')"
-          >
-            H1
-          </button>
-          <button
-            type="button"
-            :disabled="contentTab === 'preview'"
-            @click="prefixLine('## ')"
-          >
-            H2
-          </button>
-          <button
-            type="button"
-            :disabled="contentTab === 'preview'"
-            @click="prefixLine('- ')"
-          >
-            • List
-          </button>
-          <button
-            type="button"
-            :disabled="contentTab === 'preview'"
-            aria-label="Insert link"
-            @click="wrapSelection('[', '](url)')"
-          >
-            🔗
-          </button>
+          <template v-if="contentTab === 'write'">
+            <button type="button" @click="wrapSelection('**')">
+              <strong>B</strong>
+            </button>
+            <button type="button" @click="wrapSelection('*')">
+              <em>I</em>
+            </button>
+            <button type="button" @click="prefixLine('# ')">H1</button>
+            <button type="button" @click="prefixLine('## ')">H2</button>
+            <button type="button" @click="prefixLine('- ')">• List</button>
+            <button
+              type="button"
+              aria-label="Insert link"
+              @click="wrapSelection('[', '](url)')"
+            >
+              🔗
+            </button>
+          </template>
           <button
             type="button"
             class="preview-toggle"
             :class="{ 'preview-toggle--active': contentTab === 'preview' }"
             @click="contentTab = contentTab === 'preview' ? 'write' : 'preview'"
           >
-            Preview
+            {{ contentTab === 'preview' ? 'Write' : 'Preview' }}
           </button>
         </div>
 

--- a/src/pages/entryEditor.new.stories.ts
+++ b/src/pages/entryEditor.new.stories.ts
@@ -119,12 +119,22 @@ export const PreviewTogglesRenderedMarkdown: Story = {
     await expect(
       canvas.getByText('bold text', { selector: 'strong' }),
     ).toBeInTheDocument();
+    // The formatting toolbar buttons are hidden in preview mode so the
+    // preview reads visibly differently from the write view, and the
+    // toggle button itself flips to "Write".
+    await expect(
+      canvas.queryByRole('button', { name: 'B' }),
+    ).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Preview')).not.toBeInTheDocument();
 
-    await userEvent.click(canvas.getByText('Preview'));
+    await userEvent.click(canvas.getByText('Write'));
     await expect(
       await canvas.findByPlaceholderText(
         'Write your entry… (markdown supported)',
       ),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'B' }),
     ).toBeInTheDocument();
   },
 };

--- a/src/pages/entryEditor.new.stories.ts
+++ b/src/pages/entryEditor.new.stories.ts
@@ -133,9 +133,7 @@ export const PreviewTogglesRenderedMarkdown: Story = {
         'Write your entry… (markdown supported)',
       ),
     ).toBeInTheDocument();
-    await expect(
-      canvas.getByRole('button', { name: 'B' }),
-    ).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'B' })).toBeInTheDocument();
   },
 };
 


### PR DESCRIPTION
Preview mode looked too similar to the write view since the disabled
formatting buttons stayed visible. Now they're hidden entirely while
previewing, and the toggle button reads "Write" to go back.