### PR TITLE
Redesign photo rows: thumbnail + caption layout, tap-to-change/edit

### DIFF
--- a/src/components/PhotoStripItem.vue
+++ b/src/components/PhotoStripItem.vue
@@ -50,19 +50,10 @@
       ✕
     </button>
   </div>
-
-  <ion-alert
-    :is-open="showRemoveConfirm"
-    header="Remove photo"
-    :message="`Remove ${filename} from this entry?`"
-    :buttons="confirmButtons"
-    @didDismiss="onConfirmDismiss"
-  />
 </template>
 
 <script setup lang="ts">
 import { computed, ref, useId, watch } from 'vue';
-import { IonAlert } from '@ionic/vue';
 
 import { useGetImageDownloadUrl } from '../generated/apiClient';
 import { pickImages } from '../composables/useImagePicker';
@@ -86,7 +77,10 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   'update:caption': [string];
+  /** Remove this row now — no confirmation needed. */
   remove: [];
+  /** Ask the parent to confirm before removing this row (see needsConfirm). */
+  'request-remove': [];
   /** The user picked a replacement image for this row. */
   change: [File];
 }>();
@@ -160,38 +154,26 @@ const captionModel = computed({
 });
 
 // --- Removal, with confirmation for already-invested content --------------
+//
+// The confirmation <ion-alert> itself lives on the parent page, not here —
+// this row (and everything in it, including an alert if one were nested
+// here) gets unmounted the moment 'remove' fires, since that's what drops
+// the row out of the parent's list. An alert mid-dismiss racing its own
+// host element's removal is exactly the crash this split avoids: Ionic
+// closes the alert by removing its element from the DOM itself, and if
+// Vue *also* tries to unmount that same element a tick later (because the
+// row it lived in just disappeared), the two can trip over each other.
+// Keeping the alert on the page, which never itself gets removed, means
+// there's nothing left for that race to happen to.
 
 const needsConfirm = computed(
   () => props.variant === 'existing' || props.caption.trim().length > 0,
 );
-const showRemoveConfirm = ref(false);
-// Only actually removes the row once the alert has finished dismissing
-// itself (see onConfirmDismiss) — removing it eagerly, from inside the
-// button handler, would tear down this component (and the still-closing
-// <ion-alert> along with it) mid-animation.
-const removalConfirmed = ref(false);
 
 function onRemoveClick() {
   if (needsConfirm.value) {
-    showRemoveConfirm.value = true;
+    emit('request-remove');
   } else {
-    emit('remove');
-  }
-}
-
-const confirmButtons = computed(() => [
-  { text: 'Cancel', role: 'cancel' },
-  {
-    text: 'Remove',
-    role: 'destructive',
-    handler: () => (removalConfirmed.value = true),
-  },
-]);
-
-function onConfirmDismiss() {
-  showRemoveConfirm.value = false;
-  if (removalConfirmed.value) {
-    removalConfirmed.value = false;
     emit('remove');
   }
 }

--- a/src/components/PhotoStripItem.vue
+++ b/src/components/PhotoStripItem.vue
@@ -1,0 +1,291 @@
+<template>
+  <div class="photo-row">
+    <button
+      type="button"
+      class="photo-row-thumb"
+      :aria-label="`Change photo ${filename}`"
+      @click="onThumbClick"
+    >
+      <img
+        v-if="thumbnailSrc && !loadFailed"
+        :src="thumbnailSrc"
+        :alt="filename"
+        class="photo-row-thumb-img"
+        @error="loadFailed = true"
+      />
+      <span
+        v-else-if="isLoadingThumbnail"
+        class="photo-row-thumb-placeholder"
+        aria-label="Loading image"
+        >⏳</span
+      >
+      <span
+        v-else
+        class="photo-row-thumb-placeholder photo-row-thumb-placeholder--error"
+        aria-label="Failed to load image"
+        >⚠️</span
+      >
+    </button>
+
+    <div class="photo-row-caption">
+      <input
+        v-if="editingCaption"
+        ref="captionInputRef"
+        v-model="draftCaption"
+        class="photo-row-caption-input"
+        placeholder="Add a caption"
+        :aria-label="`Caption for ${filename}`"
+        @blur="commitCaption"
+        @keydown.enter="($event.target as HTMLInputElement).blur()"
+      />
+      <button
+        v-else
+        type="button"
+        class="photo-row-caption-display"
+        :class="{ 'photo-row-caption-display--empty': !caption }"
+        @click="startEditingCaption"
+      >
+        {{ caption || 'Add a caption' }}
+      </button>
+    </div>
+
+    <button
+      type="button"
+      class="photo-row-remove"
+      :aria-label="`Remove image ${filename}`"
+      @click="onRemoveClick"
+    >
+      ✕
+    </button>
+  </div>
+
+  <ion-alert
+    :is-open="showRemoveConfirm"
+    header="Remove photo"
+    :message="`Remove ${filename} from this entry?`"
+    :buttons="confirmButtons"
+    @didDismiss="onConfirmDismiss"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue';
+import { IonAlert } from '@ionic/vue';
+
+import { useGetImageDownloadUrl } from '../generated/apiClient';
+import { pickImages } from '../composables/useImagePicker';
+import type { ImageDownloadResponse } from '../generated/types';
+
+/**
+ * A single photo row in the "add photos" list, shared by already-uploaded
+ * images (`variant: 'existing'`, thumbnail resolved from the server) and
+ * images queued locally but not yet uploaded (`variant: 'pending'`,
+ * thumbnail rendered from the in-memory `File` via an object URL).
+ */
+const props = defineProps<{
+  variant: 'existing' | 'pending';
+  /** Required when variant is 'existing'. */
+  imageId?: string;
+  /** Required when variant is 'pending'. */
+  file?: File;
+  filename: string;
+  caption: string;
+}>();
+
+const emit = defineEmits<{
+  /** Fired once editing ends (blur / Enter), not on every keystroke. */
+  'commit-caption': [string];
+  remove: [];
+  /** The user picked a replacement image for this row. */
+  change: [File];
+}>();
+
+async function onThumbClick() {
+  const [file] = await pickImages({ multiple: false });
+  if (file) emit('change', file);
+}
+
+// --- Thumbnail resolution -------------------------------------------------
+
+const loadFailed = ref(false);
+watch(
+  () => [props.imageId, props.file],
+  () => (loadFailed.value = false),
+);
+
+const { data, isLoading } = useGetImageDownloadUrl(
+  computed(() => props.imageId ?? ''),
+  {
+    query: {
+      enabled: computed(() => props.variant === 'existing' && !!props.imageId),
+    },
+  },
+);
+const existingThumbUrl = computed(
+  () =>
+    (data.value?.data as ImageDownloadResponse | undefined)?.thumbnail_url ??
+    (data.value?.data as ImageDownloadResponse | undefined)?.image_url ??
+    null,
+);
+
+const pendingObjectUrl = ref<string | null>(null);
+watch(
+  () => props.file,
+  (file, _old, onCleanup) => {
+    if (props.variant !== 'pending' || !file) {
+      pendingObjectUrl.value = null;
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    pendingObjectUrl.value = url;
+    onCleanup(() => URL.revokeObjectURL(url));
+  },
+  { immediate: true },
+);
+
+const thumbnailSrc = computed(() =>
+  props.variant === 'existing'
+    ? existingThumbUrl.value
+    : pendingObjectUrl.value,
+);
+const isLoadingThumbnail = computed(
+  () => props.variant === 'existing' && isLoading.value,
+);
+
+// --- Caption editing (click-to-edit; commits on blur/Enter) --------------
+
+const editingCaption = ref(false);
+const draftCaption = ref(props.caption);
+const captionInputRef = ref<HTMLInputElement | null>(null);
+
+async function startEditingCaption() {
+  draftCaption.value = props.caption;
+  editingCaption.value = true;
+  await nextTick();
+  captionInputRef.value?.focus();
+}
+
+function commitCaption() {
+  editingCaption.value = false;
+  if (draftCaption.value !== props.caption) {
+    emit('commit-caption', draftCaption.value);
+  }
+}
+
+// --- Removal, with confirmation for already-invested content --------------
+
+const needsConfirm = computed(
+  () => props.variant === 'existing' || props.caption.trim().length > 0,
+);
+const showRemoveConfirm = ref(false);
+// Only actually removes the row once the alert has finished dismissing
+// itself (see onConfirmDismiss) — removing it eagerly, from inside the
+// button handler, would tear down this component (and the still-closing
+// <ion-alert> along with it) mid-animation.
+const removalConfirmed = ref(false);
+
+function onRemoveClick() {
+  if (needsConfirm.value) {
+    showRemoveConfirm.value = true;
+  } else {
+    emit('remove');
+  }
+}
+
+const confirmButtons = computed(() => [
+  { text: 'Cancel', role: 'cancel' },
+  {
+    text: 'Remove',
+    role: 'destructive',
+    handler: () => (removalConfirmed.value = true),
+  },
+]);
+
+function onConfirmDismiss() {
+  showRemoveConfirm.value = false;
+  if (removalConfirmed.value) {
+    removalConfirmed.value = false;
+    emit('remove');
+  }
+}
+</script>
+
+<style scoped>
+.photo-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.photo-row-thumb {
+  flex-shrink: 0;
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 8px;
+  border: 1px solid var(--color-rule);
+  background: none;
+  padding: 0;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.photo-row-thumb-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.photo-row-thumb-placeholder {
+  font-size: 1.3rem;
+  color: var(--color-ink-muted);
+}
+
+.photo-row-caption {
+  flex: 1;
+  min-width: 0;
+}
+
+.photo-row-caption-input {
+  width: 100%;
+  border: 1px solid var(--color-rule);
+  border-radius: 6px;
+  background: none;
+  color: var(--color-ink);
+  font-size: 0.9rem;
+  padding: 0.4rem 0.6rem;
+  font-family: var(--font-sans);
+}
+
+.photo-row-caption-display {
+  display: block;
+  width: 100%;
+  background: none;
+  border: none;
+  text-align: left;
+  padding: 0.4rem 0;
+  font-size: 0.9rem;
+  color: var(--color-ink);
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.photo-row-caption-display--empty {
+  color: var(--color-ink-muted);
+  font-style: italic;
+}
+
+.photo-row-remove {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--color-ink-muted);
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0.3rem;
+}
+</style>

--- a/src/components/PhotoStripItem.vue
+++ b/src/components/PhotoStripItem.vue
@@ -9,7 +9,7 @@
       <img
         v-if="thumbnailSrc && !loadFailed"
         :src="thumbnailSrc"
-        :alt="filename"
+        :alt="caption || filename"
         class="photo-row-thumb-img"
         @error="loadFailed = true"
       />
@@ -28,25 +28,17 @@
     </button>
 
     <div class="photo-row-caption">
+      <label class="sr-only" :for="captionInputId"
+        >Caption for {{ filename }}</label
+      >
       <input
-        v-if="editingCaption"
-        ref="captionInputRef"
-        v-model="draftCaption"
+        :id="captionInputId"
+        v-model="captionModel"
+        type="text"
         class="photo-row-caption-input"
         placeholder="Add a caption"
-        :aria-label="`Caption for ${filename}`"
-        @blur="commitCaption"
         @keydown.enter="($event.target as HTMLInputElement).blur()"
       />
-      <button
-        v-else
-        type="button"
-        class="photo-row-caption-display"
-        :class="{ 'photo-row-caption-display--empty': !caption }"
-        @click="startEditingCaption"
-      >
-        {{ caption || 'Add a caption' }}
-      </button>
     </div>
 
     <button
@@ -69,7 +61,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from 'vue';
+import { computed, ref, useId, watch } from 'vue';
 import { IonAlert } from '@ionic/vue';
 
 import { useGetImageDownloadUrl } from '../generated/apiClient';
@@ -93,8 +85,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  /** Fired once editing ends (blur / Enter), not on every keystroke. */
-  'commit-caption': [string];
+  'update:caption': [string];
   remove: [];
   /** The user picked a replacement image for this row. */
   change: [File];
@@ -152,25 +143,21 @@ const isLoadingThumbnail = computed(
   () => props.variant === 'existing' && isLoading.value,
 );
 
-// --- Caption editing (click-to-edit; commits on blur/Enter) --------------
+// --- Caption editing --------------------------------------------------
+//
+// A real, always-present <input> rather than a button-that-becomes-an-input:
+// that keeps its role, focusability and label constant regardless of edit
+// state, so keyboard and screen-reader users get standard text-field
+// behaviour (Tab to reach it, no separate "activate to edit" step, no
+// focus lost to the page after committing) instead of a custom two-step
+// disclosure pattern. Nothing is saved to the server as the user types —
+// see the parent page for when edits are actually persisted.
 
-const editingCaption = ref(false);
-const draftCaption = ref(props.caption);
-const captionInputRef = ref<HTMLInputElement | null>(null);
-
-async function startEditingCaption() {
-  draftCaption.value = props.caption;
-  editingCaption.value = true;
-  await nextTick();
-  captionInputRef.value?.focus();
-}
-
-function commitCaption() {
-  editingCaption.value = false;
-  if (draftCaption.value !== props.caption) {
-    emit('commit-caption', draftCaption.value);
-  }
-}
+const captionInputId = useId();
+const captionModel = computed({
+  get: () => props.caption,
+  set: (value: string) => emit('update:caption', value),
+});
 
 // --- Removal, with confirmation for already-invested content --------------
 
@@ -250,33 +237,47 @@ function onConfirmDismiss() {
 
 .photo-row-caption-input {
   width: 100%;
-  border: 1px solid var(--color-rule);
+  border: 1px solid transparent;
   border-radius: 6px;
   background: none;
   color: var(--color-ink);
   font-size: 0.9rem;
   padding: 0.4rem 0.6rem;
+  margin: 0;
   font-family: var(--font-sans);
+  cursor: text;
 }
 
-.photo-row-caption-display {
-  display: block;
-  width: 100%;
-  background: none;
-  border: none;
-  text-align: left;
-  padding: 0.4rem 0;
-  font-size: 0.9rem;
-  color: var(--color-ink);
-  cursor: pointer;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.photo-row-caption-input:hover {
+  border-color: var(--color-rule);
 }
 
-.photo-row-caption-display--empty {
+/* Keep the browser's default focus ring (never suppressed) — this is the
+   primary visible cue that the field is focused and editable for keyboard
+   and low-vision users, on top of the border filling in. */
+.photo-row-caption-input:focus {
+  border-color: var(--color-ink);
+}
+
+.photo-row-caption-input::placeholder {
   color: var(--color-ink-muted);
   font-style: italic;
+}
+
+/* Visually hidden but still announced by screen readers — pairs with the
+   caption <input>'s id/for so the field always has an accessible name,
+   even though the placeholder already carries the empty-state hint
+   visually. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .photo-row-remove {

--- a/src/composables/useImagePicker.ts
+++ b/src/composables/useImagePicker.ts
@@ -6,17 +6,23 @@ import { Camera } from '@capacitor/camera';
  * Capacitor) and falling back to a plain file input on web/PWA. Always resolves to real
  * `File` objects so callers don't need to branch on platform themselves — the multipart
  * create/edit endpoints just want File[] regardless of where they came from.
+ *
+ * Pass `{ multiple: false }` to restrict the picker to a single image (e.g. replacing one
+ * photo already queued for upload).
  */
-export async function pickImages(): Promise<File[]> {
+export async function pickImages(options?: {
+  multiple?: boolean;
+}): Promise<File[]> {
+  const multiple = options?.multiple ?? true;
   if (Capacitor.isNativePlatform()) {
-    return pickImagesNative();
+    return pickImagesNative(multiple);
   }
-  return pickImagesWeb();
+  return pickImagesWeb(multiple);
 }
 
-async function pickImagesNative(): Promise<File[]> {
+async function pickImagesNative(multiple: boolean): Promise<File[]> {
   const { results } = await Camera.chooseFromGallery({
-    allowMultipleSelection: true,
+    allowMultipleSelection: multiple,
   });
   const files = await Promise.all(
     results.map(async (result, index) => {
@@ -34,12 +40,12 @@ async function pickImagesNative(): Promise<File[]> {
   return files.filter((f): f is File => f !== null);
 }
 
-function pickImagesWeb(): Promise<File[]> {
+function pickImagesWeb(multiple: boolean): Promise<File[]> {
   return new Promise((resolve) => {
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = 'image/*';
-    input.multiple = true;
+    input.multiple = multiple;
     input.style.display = 'none';
     input.addEventListener(
       'change',

--- a/src/composables/useMarkdownEditor.ts
+++ b/src/composables/useMarkdownEditor.ts
@@ -2,52 +2,21 @@ import type { Ref } from 'vue';
 import { nextTick } from 'vue';
 
 /**
- * Returns helper functions for inserting image markdown into an Ionic
- * ion-textarea and scrolling the cursor into view as the textarea grows.
+ * Returns helper functions for formatting markdown in an Ionic ion-textarea
+ * and scrolling the cursor into view as the textarea grows.
  *
  * @param content - reactive ref for the textarea's string value
  * @param textareaRef - ref to the IonTextarea component instance
- * @param contentTab - reactive ref for the active content tab ('write'|'preview')
  */
 export function useMarkdownEditor(
   content: Ref<string>,
   textareaRef: Ref<{ $el: HTMLElement } | null>,
-  contentTab: Ref<'write' | 'preview'>,
 ) {
   /** Scroll the textarea host into view so the cursor stays visible as text grows. */
   async function onTextareaInput(event: Event) {
     await nextTick();
     const el = event.target as HTMLElement | null;
     el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-  }
-
-  /**
-   * Insert `![caption](filename)` at the current cursor position. Falls back
-   * to appending at the end when cursor info is unavailable, and switches to
-   * the write tab so the user can see the result.
-   */
-  async function insertImageMarkdown(filename: string) {
-    const snippet = `![caption](${filename})`;
-    const nativeTextarea = textareaRef.value?.$el?.querySelector('textarea');
-    if (nativeTextarea) {
-      const start = nativeTextarea.selectionStart ?? content.value.length;
-      const end = nativeTextarea.selectionEnd ?? content.value.length;
-      const before = content.value.slice(0, start);
-      const after = content.value.slice(end);
-      const needsBefore =
-        before.length > 0 && !before.endsWith('\n') ? '\n' : '';
-      const needsAfter =
-        after.length > 0 && !after.startsWith('\n') ? '\n' : '';
-      content.value = `${before}${needsBefore}${snippet}${needsAfter}${after}`;
-      await nextTick();
-      const newPos = start + needsBefore.length + snippet.length;
-      nativeTextarea.selectionStart = newPos;
-      nativeTextarea.selectionEnd = newPos;
-      nativeTextarea.focus();
-    } else {
-      content.value = content.value ? `${content.value}\n${snippet}` : snippet;
-    }
-    contentTab.value = 'write';
   }
 
   /** Wrap the current selection (or insert at the cursor) with markdown syntax. */
@@ -95,7 +64,6 @@ export function useMarkdownEditor(
 
   return {
     onTextareaInput,
-    insertImageMarkdown,
     wrapSelection,
     prefixLine,
   };

--- a/src/composables/usePhotoRemoveConfirm.ts
+++ b/src/composables/usePhotoRemoveConfirm.ts
@@ -1,0 +1,50 @@
+import { computed, ref } from 'vue';
+
+export interface PendingPhotoRemoval {
+  kind: 'existing' | 'pending';
+  id: string;
+  filename: string;
+}
+
+/**
+ * Shared state for a single confirmation `<ion-alert>` that gates removing a
+ * photo row, meant to be rendered once on the page rather than once per row.
+ *
+ * A row's own removal (PhotoStripItem's 'remove' emit) unmounts that row —
+ * if the confirmation alert lived inside the row instead, Ionic closing the
+ * alert (which removes its own element from the DOM) and Vue unmounting the
+ * same row a tick later can race and throw. Hoisting the alert onto the
+ * page, which the removal never itself unmounts, avoids that entirely.
+ */
+export function usePhotoRemoveConfirm(
+  onConfirmed: (removal: PendingPhotoRemoval) => void,
+) {
+  const pending = ref<PendingPhotoRemoval | null>(null);
+  const confirmed = ref(false);
+
+  function requestRemove(removal: PendingPhotoRemoval) {
+    pending.value = removal;
+  }
+
+  const buttons = computed(() => [
+    { text: 'Cancel', role: 'cancel' },
+    {
+      text: 'Remove',
+      role: 'destructive',
+      handler: () => (confirmed.value = true),
+    },
+  ]);
+
+  // Only acts once the alert has actually finished dismissing (didDismiss),
+  // not from inside the button handler — see the module doc comment above.
+  function onDismiss() {
+    const target = pending.value;
+    pending.value = null;
+    if (confirmed.value && target) {
+      confirmed.value = false;
+      onConfirmed(target);
+    }
+  }
+
+  return { pending, requestRemove, buttons, onDismiss };
+}

--- a/src/pages/entry.[pathId].[entryId].edit.vue
+++ b/src/pages/entry.[pathId].[entryId].edit.vue
@@ -80,7 +80,7 @@
             :image-id="img.id"
             :filename="img.filename"
             :caption="img.caption ?? ''"
-            @commit-caption="(caption) => updateExistingCaption(img, caption)"
+            @update:caption="(caption) => (img.caption = caption)"
             @change="(file) => replaceExistingImage(img, file)"
             @remove="removeExistingImage(img.id)"
           />
@@ -90,8 +90,7 @@
             variant="pending"
             :file="img.file"
             :filename="img.file.name"
-            :caption="img.caption"
-            @commit-caption="(caption) => (img.caption = caption)"
+            v-model:caption="img.caption"
             @change="(file) => (img.file = file)"
             @remove="removePendingImage(img.id)"
           />
@@ -137,7 +136,11 @@ import MarkdownContent from '../components/MarkdownContent.vue';
 import PhotoStripItem from '../components/PhotoStripItem.vue';
 import SavingOverlay from '../components/SavingOverlay.vue';
 import { useMarkdownEditor } from '../composables/useMarkdownEditor';
-import type { EntryContentResponse, ImageResponse } from '../generated/types';
+import type {
+  EntryContentResponse,
+  ImageCaptionUpdateResponse,
+  ImageResponse,
+} from '../generated/types';
 
 const route = useRoute<'/entry.[pathId].[entryId].edit'>();
 const router = useRouter();
@@ -167,6 +170,10 @@ const { mutateAsync: doUpdateEntry } = useUpdateEntry({
 
 const contentTab = ref<'write' | 'preview'>('write');
 const keptImages = ref<ImageResponse[]>([]);
+// Snapshot of each kept image's caption as last loaded from the server, so
+// submit() can tell which captions were actually edited (and only persist
+// those) rather than re-sending every caption on every save.
+const originalCaptions = ref<Map<string, string | null>>(new Map());
 const removedImageIds = ref<string[]>([]);
 const pendingImages = ref<{ id: string; file: File; caption: string }[]>([]);
 const saving = ref(false);
@@ -207,6 +214,9 @@ watch(imagesData, (images) => {
     // Query results are deeply readonly (shared TanStack Query cache
     // entries) — clone so caption edits below can mutate freely.
     keptImages.value = images.map((img) => ({ ...img }));
+    originalCaptions.value = new Map(
+      images.map((img) => [img.id, img.caption]),
+    );
     removedImageIds.value = [];
   }
 });
@@ -223,21 +233,6 @@ function removeExistingImage(imageId: string) {
   if (idx !== -1) {
     keptImages.value.splice(idx, 1);
     removedImageIds.value.push(imageId);
-  }
-}
-
-async function updateExistingCaption(image: ImageResponse, caption: string) {
-  if (entryData.value?.edit_id === undefined) return;
-  const previousCaption = image.caption;
-  image.caption = caption;
-  try {
-    await doUpdateImageCaption({
-      imageId: image.id,
-      data: { caption, expected_edit_id: entryData.value.edit_id },
-    });
-  } catch (err: unknown) {
-    image.caption = previousCaption;
-    error.value = describeError('update caption', err);
   }
 }
 
@@ -269,11 +264,29 @@ async function submit() {
   conflictError.value = '';
 
   try {
+    // Caption edits on already-uploaded images are held only in local state
+    // (see keptImages/originalCaptions above) until Save is actually
+    // pressed. Persist just the ones that changed, one request at a time —
+    // each response bumps the entry's edit_id, which the *next* request
+    // (including the final entry update below) must present back for
+    // optimistic-concurrency checking.
+    let expectedEditId = entryData.value.edit_id;
+    const changedCaptionImages = keptImages.value.filter(
+      (img) => img.caption !== (originalCaptions.value.get(img.id) ?? null),
+    );
+    for (const img of changedCaptionImages) {
+      const result = await doUpdateImageCaption({
+        imageId: img.id,
+        data: { caption: img.caption, expected_edit_id: expectedEditId },
+      });
+      expectedEditId = (result.data as ImageCaptionUpdateResponse).edit_id;
+    }
+
     await doUpdateEntry({
       pathCode: pathId,
       entrySlug: entryId,
       data: {
-        expected_edit_id: entryData.value.edit_id,
+        expected_edit_id: expectedEditId,
         content: content.value,
         captions: pendingImages.value.map((img) => img.caption),
         remove_image_ids: removedImageIds.value,

--- a/src/pages/entry.[pathId].[entryId].edit.vue
+++ b/src/pages/entry.[pathId].[entryId].edit.vue
@@ -83,6 +83,13 @@
             @update:caption="(caption) => (img.caption = caption)"
             @change="(file) => replaceExistingImage(img, file)"
             @remove="removeExistingImage(img.id)"
+            @request-remove="
+              requestRemove({
+                kind: 'existing',
+                id: img.id,
+                filename: img.filename,
+              })
+            "
           />
           <PhotoStripItem
             v-for="img in pendingImages"
@@ -93,6 +100,13 @@
             v-model:caption="img.caption"
             @change="(file) => (img.file = file)"
             @remove="removePendingImage(img.id)"
+            @request-remove="
+              requestRemove({
+                kind: 'pending',
+                id: img.id,
+                filename: img.file.name,
+              })
+            "
           />
           <button
             type="button"
@@ -113,11 +127,23 @@
       </div>
     </ion-content>
     <SavingOverlay :active="saving" :label="saveLabel" />
+
+    <ion-alert
+      :is-open="pendingRemoval !== null"
+      header="Remove photo"
+      :message="
+        pendingRemoval
+          ? `Remove ${pendingRemoval.filename} from this entry?`
+          : ''
+      "
+      :buttons="removeConfirmButtons"
+      @didDismiss="onRemoveConfirmDismiss"
+    />
   </ion-page>
 </template>
 
 <script setup lang="ts">
-import { IonPage, IonContent, IonTextarea } from '@ionic/vue';
+import { IonAlert, IonPage, IonContent, IonTextarea } from '@ionic/vue';
 import { computed, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useQueryClient } from '@tanstack/vue-query';
@@ -131,6 +157,7 @@ import {
 import { usePaths } from '../composables/usePaths';
 import { useLocalDraft } from '../composables/useLocalDraft';
 import { pickImages } from '../composables/useImagePicker';
+import { usePhotoRemoveConfirm } from '../composables/usePhotoRemoveConfirm';
 import { describeError, isApiErrorWithStatus } from '../lib/errors';
 import MarkdownContent from '../components/MarkdownContent.vue';
 import PhotoStripItem from '../components/PhotoStripItem.vue';
@@ -255,6 +282,16 @@ async function addImages() {
 function removePendingImage(id: string) {
   pendingImages.value = pendingImages.value.filter((img) => img.id !== id);
 }
+
+const {
+  pending: pendingRemoval,
+  requestRemove,
+  buttons: removeConfirmButtons,
+  onDismiss: onRemoveConfirmDismiss,
+} = usePhotoRemoveConfirm((removal) => {
+  if (removal.kind === 'existing') removeExistingImage(removal.id);
+  else removePendingImage(removal.id);
+});
 
 async function submit() {
   if (!content.value.trim() || entryData.value?.edit_id === undefined) return;

--- a/src/pages/entry.[pathId].[entryId].edit.vue
+++ b/src/pages/entry.[pathId].[entryId].edit.vue
@@ -71,74 +71,44 @@
         </p>
         <p v-else-if="error" class="editor-error">{{ error }}</p>
 
-        <template v-if="keptImages.length > 0 || removedImages.length > 0">
-          <p class="editor-section-label">Images</p>
-          <div class="existing-images">
-            <div
-              v-for="img in keptImages"
-              :key="img.id"
-              class="existing-image-item"
-            >
-              <span class="existing-image-name">{{ img.filename }}</span>
-              <button
-                class="image-action-btn"
-                type="button"
-                :aria-label="`Insert image ${img.filename} into content`"
-                @click="insertImageMarkdown(img.filename)"
-              >
-                ↳ Insert
-              </button>
-              <button
-                class="image-action-btn image-action-btn--danger"
-                type="button"
-                :aria-label="`Remove image ${img.filename}`"
-                @click="removeImage(img.id)"
-              >
-                ✕
-              </button>
-            </div>
-            <div
-              v-for="img in removedImages"
-              :key="img.id"
-              class="existing-image-item existing-image-item--removed"
-            >
-              <span class="existing-image-name">{{ img.filename }}</span>
-              <button
-                class="image-action-btn"
-                type="button"
-                :aria-label="`Restore image ${img.filename}`"
-                @click="restoreImage(img.id)"
-              >
-                ↩ Restore
-              </button>
-            </div>
-          </div>
-        </template>
-
-        <p class="editor-section-label">Add photos</p>
-        <div class="photo-strip">
-          <div
+        <p class="editor-section-label">Photos</p>
+        <div class="photo-list">
+          <PhotoStripItem
+            v-for="img in keptImages"
+            :key="img.id"
+            variant="existing"
+            :image-id="img.id"
+            :filename="img.filename"
+            :caption="img.caption ?? ''"
+            @commit-caption="(caption) => updateExistingCaption(img, caption)"
+            @change="(file) => replaceExistingImage(img, file)"
+            @remove="removeExistingImage(img.id)"
+          />
+          <PhotoStripItem
             v-for="img in pendingImages"
-            :key="img.file.name"
-            class="photo-pending"
+            :key="img.id"
+            variant="pending"
+            :file="img.file"
+            :filename="img.file.name"
+            :caption="img.caption"
+            @commit-caption="(caption) => (img.caption = caption)"
+            @change="(file) => (img.file = file)"
+            @remove="removePendingImage(img.id)"
+          />
+          <button
+            type="button"
+            class="photo-row photo-row--add"
+            @click="addImages"
           >
-            <span class="photo-pending-name">{{ img.file.name }}</span>
-            <input
-              v-model="img.caption"
-              placeholder="Caption"
-              class="photo-caption-input"
-            />
-            <button
-              class="photo-insert-btn"
-              type="button"
-              :aria-label="`Insert image ${img.file.name} into content`"
-              @click="insertImageMarkdown(img.file.name)"
+            <span
+              class="photo-row-thumb photo-row-thumb--add"
+              aria-hidden="true"
+              >+</span
             >
-              ↳
-            </button>
-          </div>
-          <button class="photo-add-btn" type="button" @click="addImages">
-            +
+            <span
+              class="photo-row-caption-display photo-row-caption-display--empty"
+              >Add an image</span
+            >
           </button>
         </div>
       </div>
@@ -157,12 +127,14 @@ import {
   useGetEntry,
   useListEntryImages,
   useUpdateEntry,
+  useUpdateImageCaption,
 } from '../generated/apiClient';
 import { usePaths } from '../composables/usePaths';
 import { useLocalDraft } from '../composables/useLocalDraft';
 import { pickImages } from '../composables/useImagePicker';
 import { describeError, isApiErrorWithStatus } from '../lib/errors';
 import MarkdownContent from '../components/MarkdownContent.vue';
+import PhotoStripItem from '../components/PhotoStripItem.vue';
 import SavingOverlay from '../components/SavingOverlay.vue';
 import { useMarkdownEditor } from '../composables/useMarkdownEditor';
 import type { EntryContentResponse, ImageResponse } from '../generated/types';
@@ -195,8 +167,8 @@ const { mutateAsync: doUpdateEntry } = useUpdateEntry({
 
 const contentTab = ref<'write' | 'preview'>('write');
 const keptImages = ref<ImageResponse[]>([]);
-const removedImages = ref<ImageResponse[]>([]);
-const pendingImages = ref<{ file: File; caption: string }[]>([]);
+const removedImageIds = ref<string[]>([]);
+const pendingImages = ref<{ id: string; file: File; caption: string }[]>([]);
 const saving = ref(false);
 const error = ref('');
 const conflictError = ref('');
@@ -231,31 +203,62 @@ watch(
   { immediate: true },
 );
 watch(imagesData, (images) => {
-  if (images) keptImages.value = [...images];
+  if (images) {
+    // Query results are deeply readonly (shared TanStack Query cache
+    // entries) — clone so caption edits below can mutate freely.
+    keptImages.value = images.map((img) => ({ ...img }));
+    removedImageIds.value = [];
+  }
 });
 
-const { onTextareaInput, insertImageMarkdown, wrapSelection, prefixLine } =
-  useMarkdownEditor(content, textareaRef, contentTab);
+const { onTextareaInput, wrapSelection, prefixLine } = useMarkdownEditor(
+  content,
+  textareaRef,
+);
 
-function removeImage(imageId: string) {
+const { mutateAsync: doUpdateImageCaption } = useUpdateImageCaption();
+
+function removeExistingImage(imageId: string) {
   const idx = keptImages.value.findIndex((img) => img.id === imageId);
   if (idx !== -1) {
-    const [removed] = keptImages.value.splice(idx, 1);
-    if (removed) removedImages.value.push(removed);
+    keptImages.value.splice(idx, 1);
+    removedImageIds.value.push(imageId);
   }
 }
 
-function restoreImage(imageId: string) {
-  const idx = removedImages.value.findIndex((img) => img.id === imageId);
-  if (idx !== -1) {
-    const [restored] = removedImages.value.splice(idx, 1);
-    if (restored) keptImages.value.push(restored);
+async function updateExistingCaption(image: ImageResponse, caption: string) {
+  if (entryData.value?.edit_id === undefined) return;
+  const previousCaption = image.caption;
+  image.caption = caption;
+  try {
+    await doUpdateImageCaption({
+      imageId: image.id,
+      data: { caption, expected_edit_id: entryData.value.edit_id },
+    });
+  } catch (err: unknown) {
+    image.caption = previousCaption;
+    error.value = describeError('update caption', err);
   }
+}
+
+function replaceExistingImage(image: ImageResponse, file: File) {
+  removeExistingImage(image.id);
+  pendingImages.value.push({
+    id: crypto.randomUUID(),
+    file,
+    caption: image.caption ?? '',
+  });
 }
 
 async function addImages() {
   const files = await pickImages();
-  pendingImages.value.push(...files.map((file) => ({ file, caption: '' })));
+  pendingImages.value.push(
+    ...files.map((file) => ({ id: crypto.randomUUID(), file, caption: '' })),
+  );
+}
+
+function removePendingImage(id: string) {
+  pendingImages.value = pendingImages.value.filter((img) => img.id !== id);
 }
 
 async function submit() {
@@ -273,7 +276,7 @@ async function submit() {
         expected_edit_id: entryData.value.edit_id,
         content: content.value,
         captions: pendingImages.value.map((img) => img.caption),
-        remove_image_ids: removedImages.value.map((img) => img.id),
+        remove_image_ids: removedImageIds.value,
         images: pendingImages.value.map((img) => img.file),
       },
     });
@@ -427,95 +430,40 @@ async function submit() {
   margin: 1.5rem 0 0.6rem;
 }
 
-.existing-images {
+.photo-list {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.6rem;
 }
 
-.existing-image-item {
+.photo-row--add {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.875rem;
-}
-
-.existing-image-item--removed .existing-image-name {
-  text-decoration: line-through;
-  color: var(--color-ink-muted);
-}
-
-.existing-image-name {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.image-action-btn {
+  gap: 0.75rem;
+  width: 100%;
   background: none;
-  border: 1px solid var(--color-rule);
-  border-radius: 4px;
+  border: none;
+  padding: 0;
+  text-align: left;
   cursor: pointer;
-  font-size: 0.75rem;
-  padding: 0.15rem 0.5rem;
-  color: var(--color-ink);
 }
 
-.image-action-btn--danger {
-  color: var(--ion-color-danger);
-}
-
-.photo-strip {
-  display: flex;
-  gap: 0.6rem;
-  flex-wrap: wrap;
-  align-items: flex-start;
-}
-
-.photo-pending {
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
-  width: 6rem;
-  font-size: 0.75rem;
-}
-
-.photo-pending-name {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--color-ink-muted);
-}
-
-.photo-caption-input {
-  border: 1px solid var(--color-rule);
-  border-radius: 4px;
-  background: none;
-  color: var(--color-ink);
-  font-size: 0.75rem;
-  padding: 0.2rem 0.3rem;
-}
-
-.photo-insert-btn {
-  align-self: flex-start;
-  background: none;
-  border: 1px solid var(--color-rule);
-  border-radius: 4px;
-  color: var(--color-ink);
-  cursor: pointer;
-  font-size: 0.75rem;
-  padding: 0.1rem 0.4rem;
-}
-
-.photo-add-btn {
+.photo-row-thumb--add {
+  flex-shrink: 0;
   width: 3.5rem;
   height: 3.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border: 1px dashed var(--color-rule);
-  border-radius: 6px;
-  background: none;
+  border-radius: 8px;
   color: var(--color-ink-muted);
   font-size: 1.3rem;
-  cursor: pointer;
+}
+
+.photo-row-caption-display--empty {
+  color: var(--color-ink-muted);
+  font-style: italic;
+  font-size: 0.9rem;
 }
 </style>

--- a/src/pages/entry.new.vue
+++ b/src/pages/entry.new.vue
@@ -90,29 +90,32 @@
         <p v-if="error" class="editor-error">{{ error }}</p>
 
         <p class="editor-section-label">Photos</p>
-        <div class="photo-strip">
-          <div
+        <div class="photo-list">
+          <PhotoStripItem
             v-for="img in pendingImages"
-            :key="img.file.name"
-            class="photo-pending"
+            :key="img.id"
+            variant="pending"
+            :file="img.file"
+            :filename="img.file.name"
+            :caption="img.caption"
+            @commit-caption="(caption) => (img.caption = caption)"
+            @change="(file) => (img.file = file)"
+            @remove="removePendingImage(img.id)"
+          />
+          <button
+            type="button"
+            class="photo-row photo-row--add"
+            @click="addImages"
           >
-            <span class="photo-pending-name">{{ img.file.name }}</span>
-            <input
-              v-model="img.caption"
-              placeholder="Caption"
-              class="photo-caption-input"
-            />
-            <button
-              class="photo-insert-btn"
-              type="button"
-              :aria-label="`Insert image ${img.file.name} into content`"
-              @click="insertImageMarkdown(img.file.name)"
+            <span
+              class="photo-row-thumb photo-row-thumb--add"
+              aria-hidden="true"
+              >+</span
             >
-              ↳
-            </button>
-          </div>
-          <button class="photo-add-btn" type="button" @click="addImages">
-            +
+            <span
+              class="photo-row-caption-display photo-row-caption-display--empty"
+              >Add an image</span
+            >
           </button>
         </div>
       </div>
@@ -133,6 +136,7 @@ import { useLocalDraft } from '../composables/useLocalDraft';
 import { pickImages } from '../composables/useImagePicker';
 import { describeError } from '../lib/errors';
 import MarkdownContent from '../components/MarkdownContent.vue';
+import PhotoStripItem from '../components/PhotoStripItem.vue';
 import SavingOverlay from '../components/SavingOverlay.vue';
 import { useMarkdownEditor } from '../composables/useMarkdownEditor';
 import { toLocalISODate } from '../utils/date';
@@ -179,7 +183,7 @@ const selectedPathId = ref(initialPathId);
 const day = ref(initialDay);
 const contentTab = ref<'write' | 'preview'>('write');
 const error = ref('');
-const pendingImages = ref<{ file: File; caption: string }[]>([]);
+const pendingImages = ref<{ id: string; file: File; caption: string }[]>([]);
 const textareaRef = ref<InstanceType<typeof IonTextarea> | null>(null);
 
 const saveLabel = computed(() => {
@@ -223,12 +227,20 @@ const {
 } = useLocalDraft(pathId, day, ref(null));
 onMounted(restore);
 
-const { onTextareaInput, insertImageMarkdown, wrapSelection, prefixLine } =
-  useMarkdownEditor(content, textareaRef, contentTab);
+const { onTextareaInput, wrapSelection, prefixLine } = useMarkdownEditor(
+  content,
+  textareaRef,
+);
 
 async function addImages() {
   const files = await pickImages();
-  pendingImages.value.push(...files.map((file) => ({ file, caption: '' })));
+  pendingImages.value.push(
+    ...files.map((file) => ({ id: crypto.randomUUID(), file, caption: '' })),
+  );
+}
+
+function removePendingImage(id: string) {
+  pendingImages.value = pendingImages.value.filter((img) => img.id !== id);
 }
 
 async function submit() {
@@ -401,56 +413,40 @@ async function submit() {
   margin: 1.5rem 0 0.6rem;
 }
 
-.photo-strip {
-  display: flex;
-  gap: 0.6rem;
-  flex-wrap: wrap;
-  align-items: flex-start;
-}
-
-.photo-pending {
+.photo-list {
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
-  width: 6rem;
-  font-size: 0.75rem;
+  gap: 0.6rem;
 }
 
-.photo-pending-name {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--color-ink-muted);
-}
-
-.photo-caption-input {
-  border: 1px solid var(--color-rule);
-  border-radius: 4px;
+.photo-row--add {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
   background: none;
-  color: var(--color-ink);
-  font-size: 0.75rem;
-  padding: 0.2rem 0.3rem;
-}
-
-.photo-insert-btn {
-  align-self: flex-start;
-  background: none;
-  border: 1px solid var(--color-rule);
-  border-radius: 4px;
-  color: var(--color-ink);
+  border: none;
+  padding: 0;
+  text-align: left;
   cursor: pointer;
-  font-size: 0.75rem;
-  padding: 0.1rem 0.4rem;
 }
 
-.photo-add-btn {
+.photo-row-thumb--add {
+  flex-shrink: 0;
   width: 3.5rem;
   height: 3.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border: 1px dashed var(--color-rule);
-  border-radius: 6px;
-  background: none;
+  border-radius: 8px;
   color: var(--color-ink-muted);
   font-size: 1.3rem;
-  cursor: pointer;
+}
+
+.photo-row-caption-display--empty {
+  color: var(--color-ink-muted);
+  font-style: italic;
+  font-size: 0.9rem;
 }
 </style>

--- a/src/pages/entry.new.vue
+++ b/src/pages/entry.new.vue
@@ -100,6 +100,13 @@
             v-model:caption="img.caption"
             @change="(file) => (img.file = file)"
             @remove="removePendingImage(img.id)"
+            @request-remove="
+              requestRemove({
+                kind: 'pending',
+                id: img.id,
+                filename: img.file.name,
+              })
+            "
           />
           <button
             type="button"
@@ -120,11 +127,23 @@
       </div>
     </ion-content>
     <SavingOverlay :active="saving" :label="saveLabel" />
+
+    <ion-alert
+      :is-open="pendingRemoval !== null"
+      header="Remove photo"
+      :message="
+        pendingRemoval
+          ? `Remove ${pendingRemoval.filename} from this entry?`
+          : ''
+      "
+      :buttons="removeConfirmButtons"
+      @didDismiss="onRemoveConfirmDismiss"
+    />
   </ion-page>
 </template>
 
 <script setup lang="ts">
-import { IonPage, IonContent, IonTextarea } from '@ionic/vue';
+import { IonAlert, IonPage, IonContent, IonTextarea } from '@ionic/vue';
 import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useQueryClient } from '@tanstack/vue-query';
@@ -133,6 +152,7 @@ import { useCreateEntry } from '../generated/apiClient';
 import { usePaths } from '../composables/usePaths';
 import { useLocalDraft } from '../composables/useLocalDraft';
 import { pickImages } from '../composables/useImagePicker';
+import { usePhotoRemoveConfirm } from '../composables/usePhotoRemoveConfirm';
 import { describeError } from '../lib/errors';
 import MarkdownContent from '../components/MarkdownContent.vue';
 import PhotoStripItem from '../components/PhotoStripItem.vue';
@@ -241,6 +261,13 @@ async function addImages() {
 function removePendingImage(id: string) {
   pendingImages.value = pendingImages.value.filter((img) => img.id !== id);
 }
+
+const {
+  pending: pendingRemoval,
+  requestRemove,
+  buttons: removeConfirmButtons,
+  onDismiss: onRemoveConfirmDismiss,
+} = usePhotoRemoveConfirm((removal) => removePendingImage(removal.id));
 
 async function submit() {
   if (!selectedPathId.value || !day.value || !content.value) return;

--- a/src/pages/entry.new.vue
+++ b/src/pages/entry.new.vue
@@ -97,8 +97,7 @@
             variant="pending"
             :file="img.file"
             :filename="img.file.name"
-            :caption="img.caption"
-            @commit-caption="(caption) => (img.caption = caption)"
+            v-model:caption="img.caption"
             @change="(file) => (img.file = file)"
             @remove="removePendingImage(img.id)"
           />

--- a/src/pages/entryEditor.edit.stories.ts
+++ b/src/pages/entryEditor.edit.stories.ts
@@ -9,6 +9,7 @@ import {
   routeLoader,
   clearLocalDraftsLoader,
 } from '../../.storybook/decorators';
+import { withDefaultHandlers } from '../../.storybook/msw';
 import { db } from '../lib/db';
 
 // Unique ids so this story's local-draft autosave (persisted to real
@@ -59,7 +60,7 @@ function entryReadHandlers(images: unknown[] = []) {
   ];
 }
 
-const readHandlers = entryReadHandlers();
+const readHandlers = withDefaultHandlers(...entryReadHandlers());
 
 // pickImages() falls back to a plain <input type="file"> appended to
 // document.body and clicked (see useImagePicker.ts) — there's no real OS
@@ -249,53 +250,143 @@ export const ConflictShowsInlineWarning: Story = {
   },
 };
 
-export const ExistingImageCanBeRemovedAndRestored: Story = {
+export const ExistingImageRequiresConfirmationToRemove: Story = {
   parameters: {
-    msw: { handlers: entryReadHandlers([existingImage]) },
+    msw: {
+      handlers: withDefaultHandlers(...entryReadHandlers([existingImage])),
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(await canvas.findByText('beach.jpg')).toBeInTheDocument();
+    await expect(
+      await canvas.findByLabelText('Change photo beach.jpg'),
+    ).toBeInTheDocument();
 
     await userEvent.click(canvas.getByLabelText('Remove image beach.jpg'));
-    const removedItem = canvas
-      .getByText('beach.jpg')
-      .closest('.existing-image-item');
-    await expect(removedItem).toHaveClass('existing-image-item--removed');
-    await expect(
-      canvas.queryByLabelText('Remove image beach.jpg'),
-    ).not.toBeInTheDocument();
+    await expect(await screen.findByText('Remove photo')).toBeInTheDocument();
 
-    await userEvent.click(canvas.getByLabelText('Restore image beach.jpg'));
-    const restoredItem = canvas
-      .getByText('beach.jpg')
-      .closest('.existing-image-item');
-    await expect(restoredItem).not.toHaveClass('existing-image-item--removed');
+    // Cancelling leaves the photo in place.
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     await expect(
       canvas.getByLabelText('Remove image beach.jpg'),
+    ).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByLabelText('Remove image beach.jpg'));
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Remove' }),
+    );
+    await waitFor(() =>
+      expect(
+        canvas.queryByLabelText('Remove image beach.jpg'),
+      ).not.toBeInTheDocument(),
+    );
+  },
+};
+
+export const ExistingImageCaptionCanBeEditedByTapping: Story = {
+  parameters: {
+    msw: {
+      handlers: withDefaultHandlers(
+        ...entryReadHandlers([existingImage]),
+        http.patch('*/v1/images/:imageId', () =>
+          HttpResponse.json({
+            edit_id: 2,
+            image: { ...existingImage, caption: 'Sunset over the bay' },
+          }),
+        ),
+      ),
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByLabelText('Change photo beach.jpg');
+
+    await userEvent.click(canvas.getByText('Add a caption'));
+    await userEvent.type(
+      canvas.getByPlaceholderText('Add a caption'),
+      'Sunset over the bay',
+    );
+    await userEvent.tab();
+
+    await expect(
+      await canvas.findByText('Sunset over the bay'),
     ).toBeInTheDocument();
   },
 };
 
-export const AddingNewImageShowsInPhotoStrip: Story = {
+export const AddingNewImageShowsThumbnailAndCaptionPrompt: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await canvas.findByDisplayValue('Morning run along the river.');
 
-    await userEvent.click(canvas.getByText('+'));
+    await userEvent.click(canvas.getByRole('button', { name: 'Add an image' }));
     await selectFile(
       new File(['fake-image-bytes'], 'sunset.jpg', { type: 'image/jpeg' }),
     );
 
-    await expect(await canvas.findByText('sunset.jpg')).toBeInTheDocument();
-    await expect(canvas.getByPlaceholderText('Caption')).toBeInTheDocument();
+    await expect(
+      await canvas.findByLabelText('Change photo sunset.jpg'),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText('Add a caption')).toBeInTheDocument();
+    await expect(
+      canvas.getByLabelText('Remove image sunset.jpg'),
+    ).toBeInTheDocument();
+  },
+};
+
+export const PendingImageWithoutCaptionIsRemovedImmediately: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByDisplayValue('Morning run along the river.');
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Add an image' }));
+    await selectFile(
+      new File(['fake-image-bytes'], 'sunset.jpg', { type: 'image/jpeg' }),
+    );
+    await canvas.findByLabelText('Change photo sunset.jpg');
+
+    await userEvent.click(canvas.getByLabelText('Remove image sunset.jpg'));
+    await expect(
+      canvas.queryByLabelText('Remove image sunset.jpg'),
+    ).not.toBeInTheDocument();
+    await expect(screen.queryByText('Remove photo')).not.toBeInTheDocument();
+  },
+};
+
+export const PendingImageWithCaptionRequiresConfirmationToRemove: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByDisplayValue('Morning run along the river.');
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Add an image' }));
+    await selectFile(
+      new File(['fake-image-bytes'], 'sunset.jpg', { type: 'image/jpeg' }),
+    );
+    await userEvent.click(await canvas.findByText('Add a caption'));
+    await userEvent.type(
+      canvas.getByPlaceholderText('Add a caption'),
+      'Golden hour',
+    );
+    await userEvent.tab();
+
+    await userEvent.click(canvas.getByLabelText('Remove image sunset.jpg'));
+    await expect(await screen.findByText('Remove photo')).toBeInTheDocument();
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Remove' }),
+    );
+
+    await waitFor(() =>
+      expect(
+        canvas.queryByLabelText('Remove image sunset.jpg'),
+      ).not.toBeInTheDocument(),
+    );
   },
 };
 
 export const SavingWithImageChangesShowsPercentProgress: Story = {
   parameters: {
     msw: {
-      handlers: [
+      handlers: withDefaultHandlers(
         ...entryReadHandlers([existingImage]),
         http.put('*/v1/paths/:pathCode/entries/:entrySlug', async () => {
           await delay(5000);
@@ -307,18 +398,28 @@ export const SavingWithImageChangesShowsPercentProgress: Story = {
             content: 'Morning run along the river.',
           });
         }),
-      ],
+      ),
     },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await canvas.findByDisplayValue('Morning run along the river.');
-    await canvas.findByText('beach.jpg');
+    await canvas.findByLabelText('Change photo beach.jpg');
 
-    // Remove the existing image and add a new one, so the save request
-    // carries a real multipart upload (drives the % progress label).
+    // Remove the existing image (confirming, since it's already uploaded)
+    // and add a new one, so the save request carries a real multipart
+    // upload (drives the % progress label).
     await userEvent.click(canvas.getByLabelText('Remove image beach.jpg'));
-    await userEvent.click(canvas.getByText('+'));
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Remove' }),
+    );
+    await waitFor(() =>
+      expect(
+        canvas.queryByLabelText('Remove image beach.jpg'),
+      ).not.toBeInTheDocument(),
+    );
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Add an image' }));
     await selectFile(
       new File(['fake-image-bytes'], 'sunset.jpg', { type: 'image/jpeg' }),
     );

--- a/src/pages/entryEditor.edit.stories.ts
+++ b/src/pages/entryEditor.edit.stories.ts
@@ -283,7 +283,7 @@ export const ExistingImageRequiresConfirmationToRemove: Story = {
   },
 };
 
-export const ExistingImageCaptionCanBeEditedByTapping: Story = {
+export const ExistingImageCaptionEditPersistsOnlyOnSave: Story = {
   parameters: {
     msw: {
       handlers: withDefaultHandlers(
@@ -294,6 +294,15 @@ export const ExistingImageCaptionCanBeEditedByTapping: Story = {
             image: { ...existingImage, caption: 'Sunset over the bay' },
           }),
         ),
+        http.put('*/v1/paths/:pathCode/entries/:entrySlug', () =>
+          HttpResponse.json({
+            id: entryId,
+            path_id: path.path_id,
+            day: '2024-03-15',
+            edit_id: 3,
+            content: 'Morning run along the river.',
+          }),
+        ),
       ),
     },
   },
@@ -301,16 +310,19 @@ export const ExistingImageCaptionCanBeEditedByTapping: Story = {
     const canvas = within(canvasElement);
     await canvas.findByLabelText('Change photo beach.jpg');
 
-    await userEvent.click(canvas.getByText('Add a caption'));
-    await userEvent.type(
-      canvas.getByPlaceholderText('Add a caption'),
-      'Sunset over the bay',
-    );
-    await userEvent.tab();
+    // Typing updates the field locally straight away — nothing is sent to
+    // the server until Save is pressed.
+    const captionInput = canvas.getByPlaceholderText('Add a caption');
+    await userEvent.type(captionInput, 'Sunset over the bay');
+    await expect(captionInput).toHaveValue('Sunset over the bay');
 
+    await userEvent.click(canvas.getByText('Save'));
+    await waitFor(() =>
+      expect(canvas.queryByText('Saving…')).not.toBeInTheDocument(),
+    );
     await expect(
-      await canvas.findByText('Sunset over the bay'),
-    ).toBeInTheDocument();
+      canvas.queryByText('Unable to save entry', { exact: false }),
+    ).not.toBeInTheDocument();
   },
 };
 
@@ -327,7 +339,9 @@ export const AddingNewImageShowsThumbnailAndCaptionPrompt: Story = {
     await expect(
       await canvas.findByLabelText('Change photo sunset.jpg'),
     ).toBeInTheDocument();
-    await expect(canvas.getByText('Add a caption')).toBeInTheDocument();
+    await expect(
+      canvas.getByPlaceholderText('Add a caption'),
+    ).toBeInTheDocument();
     await expect(
       canvas.getByLabelText('Remove image sunset.jpg'),
     ).toBeInTheDocument();
@@ -362,12 +376,10 @@ export const PendingImageWithCaptionRequiresConfirmationToRemove: Story = {
     await selectFile(
       new File(['fake-image-bytes'], 'sunset.jpg', { type: 'image/jpeg' }),
     );
-    await userEvent.click(await canvas.findByText('Add a caption'));
     await userEvent.type(
-      canvas.getByPlaceholderText('Add a caption'),
+      await canvas.findByPlaceholderText('Add a caption'),
       'Golden hour',
     );
-    await userEvent.tab();
 
     await userEvent.click(canvas.getByLabelText('Remove image sunset.jpg'));
     await expect(await screen.findByText('Remove photo')).toBeInTheDocument();

--- a/src/pages/entryEditor.edit.stories.ts
+++ b/src/pages/entryEditor.edit.stories.ts
@@ -41,6 +41,16 @@ const existingImage = {
   byte_size: 1024,
 };
 
+const secondExistingImage = {
+  id: 'story-image-2',
+  entry_id: entryId,
+  filename: 'pier.jpg',
+  caption: null,
+  status: 'ready',
+  content_type: 'image/jpeg',
+  byte_size: 2048,
+};
+
 function entryReadHandlers(images: unknown[] = []) {
   return [
     http.get('*/v1/paths', () => HttpResponse.json([path])),
@@ -71,6 +81,19 @@ async function selectFile(file: File) {
     'input[type="file"]',
   ) as HTMLInputElement;
   await userEvent.upload(fileInput, file);
+}
+
+// A real (if tiny) transparent GIF — tests that assert on the rendered
+// thumbnail <img> need actual decodable image bytes, since the object URL
+// is loaded by a genuine browser <img> here (not jsdom): plain placeholder
+// text would fire a real decode error and hide the thumbnail behind the
+// component's error state.
+const PIXEL_GIF_BASE64 =
+  'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBTAA7';
+function pixelGifFile(name: string): File {
+  const binary = atob(PIXEL_GIF_BASE64);
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  return new File([bytes], name, { type: 'image/gif' });
 }
 
 const saveSucceedsHandler = http.put(
@@ -262,14 +285,31 @@ export const ExistingImageRequiresConfirmationToRemove: Story = {
       await canvas.findByLabelText('Change photo beach.jpg'),
     ).toBeInTheDocument();
 
+    // A real thumbnail, resolved from the server (the default download-url
+    // handler swaps in a placeholder image — see src/mocks/handlers.ts).
+    // findByRole (not getByRole): resolving it is a network round trip.
+    const thumb = await canvas.findByRole('img', { name: 'beach.jpg' });
+    await expect(thumb).toHaveAttribute(
+      'src',
+      expect.stringMatching(/^data:image/),
+    );
+
     await userEvent.click(canvas.getByLabelText('Remove image beach.jpg'));
-    await expect(await screen.findByText('Remove photo')).toBeInTheDocument();
+    await expect(
+      await screen.findByRole('alertdialog', { name: 'Remove photo' }),
+    ).toBeInTheDocument();
 
     // Cancelling leaves the photo in place.
     await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     await expect(
       canvas.getByLabelText('Remove image beach.jpg'),
     ).toBeInTheDocument();
+    // Let the alert actually finish closing before reopening it — Ionic's
+    // own dismiss lifecycle is async, and re-presenting mid-dismiss is a
+    // real race, not just a test artifact.
+    await waitFor(() =>
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument(),
+    );
 
     await userEvent.click(canvas.getByLabelText('Remove image beach.jpg'));
     await userEvent.click(
@@ -332,19 +372,80 @@ export const AddingNewImageShowsThumbnailAndCaptionPrompt: Story = {
     await canvas.findByDisplayValue('Morning run along the river.');
 
     await userEvent.click(canvas.getByRole('button', { name: 'Add an image' }));
-    await selectFile(
-      new File(['fake-image-bytes'], 'sunset.jpg', { type: 'image/jpeg' }),
-    );
+    await selectFile(pixelGifFile('sunset.jpg'));
 
     await expect(
       await canvas.findByLabelText('Change photo sunset.jpg'),
     ).toBeInTheDocument();
     await expect(
-      canvas.getByPlaceholderText('Add a caption'),
-    ).toBeInTheDocument();
-    await expect(
       canvas.getByLabelText('Remove image sunset.jpg'),
     ).toBeInTheDocument();
+
+    // A real thumbnail, rendered from the picked File via an object URL.
+    const thumb = await canvas.findByRole('img', { name: 'sunset.jpg' });
+    await expect(thumb).toHaveAttribute('src', expect.stringMatching(/^blob:/));
+
+    // The caption field is reachable by its accessible name (the
+    // visually-hidden <label>, not just its placeholder), and typing
+    // updates it immediately.
+    const captionInput = canvas.getByLabelText('Caption for sunset.jpg');
+    await expect(captionInput).toBe(
+      canvas.getByPlaceholderText('Add a caption'),
+    );
+    await userEvent.type(captionInput, 'Golden hour');
+    await expect(captionInput).toHaveValue('Golden hour');
+  },
+};
+
+export const TappingQueuedImageThumbnailReplacesIt: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByDisplayValue('Morning run along the river.');
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Add an image' }));
+    await selectFile(pixelGifFile('sunset.jpg'));
+    await userEvent.type(
+      await canvas.findByPlaceholderText('Add a caption'),
+      'Golden hour',
+    );
+
+    await userEvent.click(canvas.getByLabelText('Change photo sunset.jpg'));
+    await selectFile(pixelGifFile('moonrise.jpg'));
+
+    await expect(
+      await canvas.findByLabelText('Change photo moonrise.jpg'),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.queryByLabelText('Change photo sunset.jpg'),
+    ).not.toBeInTheDocument();
+    await expect(canvas.getByPlaceholderText('Add a caption')).toHaveValue(
+      'Golden hour',
+    );
+  },
+};
+
+export const TappingExistingImageThumbnailQueuesAReplacement: Story = {
+  parameters: {
+    msw: {
+      handlers: withDefaultHandlers(...entryReadHandlers([existingImage])),
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByLabelText('Change photo beach.jpg');
+
+    await userEvent.click(canvas.getByLabelText('Change photo beach.jpg'));
+    await selectFile(pixelGifFile('sunset.jpg'));
+
+    // The already-uploaded photo is replaced by a freshly queued one —
+    // still just one row, not both side by side.
+    await expect(
+      await canvas.findByLabelText('Change photo sunset.jpg'),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.queryByLabelText('Change photo beach.jpg'),
+    ).not.toBeInTheDocument();
+    await expect(canvas.getAllByRole('img')).toHaveLength(1);
   },
 };
 
@@ -363,7 +464,7 @@ export const PendingImageWithoutCaptionIsRemovedImmediately: Story = {
     await expect(
       canvas.queryByLabelText('Remove image sunset.jpg'),
     ).not.toBeInTheDocument();
-    await expect(screen.queryByText('Remove photo')).not.toBeInTheDocument();
+    await expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   },
 };
 
@@ -382,7 +483,9 @@ export const PendingImageWithCaptionRequiresConfirmationToRemove: Story = {
     );
 
     await userEvent.click(canvas.getByLabelText('Remove image sunset.jpg'));
-    await expect(await screen.findByText('Remove photo')).toBeInTheDocument();
+    await expect(
+      await screen.findByRole('alertdialog', { name: 'Remove photo' }),
+    ).toBeInTheDocument();
     await userEvent.click(
       await screen.findByRole('button', { name: 'Remove' }),
     );
@@ -461,5 +564,86 @@ export const SavingWithImageChangesShowsPercentProgress: Story = {
         ).not.toBeInTheDocument(),
       { timeout: 8000 },
     );
+  },
+};
+
+export const MultipleCaptionEditsChainEditIdThroughToSave: Story = {
+  parameters: {
+    msw: {
+      handlers: withDefaultHandlers(
+        ...entryReadHandlers([existingImage, secondExistingImage]),
+        // Each caption update bumps the entry's edit_id, and the *next*
+        // request (the second caption update, then the final entry save)
+        // must present that new value back — this handler 409s if submit()
+        // ever sends a stale one, so a chaining regression fails loudly
+        // instead of silently saving with the wrong optimistic-lock value.
+        http.patch('*/v1/images/:imageId', async ({ request, params }) => {
+          const body = (await request.json()) as {
+            caption?: string | null;
+            expected_edit_id: number;
+          };
+          if (params.imageId === existingImage.id) {
+            if (body.expected_edit_id !== 1) {
+              return HttpResponse.json({ detail: 'conflict' }, { status: 409 });
+            }
+            return HttpResponse.json({
+              edit_id: 2,
+              image: { ...existingImage, caption: body.caption ?? null },
+            });
+          }
+          if (body.expected_edit_id !== 2) {
+            return HttpResponse.json({ detail: 'conflict' }, { status: 409 });
+          }
+          return HttpResponse.json({
+            edit_id: 3,
+            image: { ...secondExistingImage, caption: body.caption ?? null },
+          });
+        }),
+        http.put(
+          '*/v1/paths/:pathCode/entries/:entrySlug',
+          async ({ request }) => {
+            const body = await request.formData();
+            if (body.get('expected_edit_id') !== '3') {
+              return HttpResponse.json({ detail: 'conflict' }, { status: 409 });
+            }
+            return HttpResponse.json({
+              id: entryId,
+              path_id: path.path_id,
+              day: '2024-03-15',
+              edit_id: 4,
+              content: 'Morning run along the river.',
+            });
+          },
+        ),
+      ),
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByLabelText('Change photo beach.jpg');
+    await canvas.findByLabelText('Change photo pier.jpg');
+
+    await userEvent.type(
+      canvas.getByLabelText('Caption for beach.jpg'),
+      'Morning swim',
+    );
+    await userEvent.type(
+      canvas.getByLabelText('Caption for pier.jpg'),
+      'Evening walk',
+    );
+
+    await userEvent.click(canvas.getByText('Save'));
+
+    await waitFor(() =>
+      expect(canvas.queryByText('Saving…')).not.toBeInTheDocument(),
+    );
+    await expect(
+      canvas.queryByText('A newer version of this entry exists', {
+        exact: false,
+      }),
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByText('Unable to save entry', { exact: false }),
+    ).not.toBeInTheDocument();
   },
 };

--- a/src/pages/entryEditor.new.stories.ts
+++ b/src/pages/entryEditor.new.stories.ts
@@ -250,7 +250,9 @@ export const AddingImageShowsThumbnailAndCaptionPrompt: Story = {
     await expect(
       await canvas.findByLabelText('Change photo sunset.jpg'),
     ).toBeInTheDocument();
-    await expect(canvas.getByText('Add a caption')).toBeInTheDocument();
+    await expect(
+      canvas.getByPlaceholderText('Add a caption'),
+    ).toBeInTheDocument();
     await expect(
       canvas.getByLabelText('Remove image sunset.jpg'),
     ).toBeInTheDocument();
@@ -285,12 +287,10 @@ export const PendingImageWithCaptionRequiresConfirmationToRemove: Story = {
     await selectFile(
       new File(['fake-image-bytes'], 'sunset.jpg', { type: 'image/jpeg' }),
     );
-    await userEvent.click(await canvas.findByText('Add a caption'));
     await userEvent.type(
-      canvas.getByPlaceholderText('Add a caption'),
+      await canvas.findByPlaceholderText('Add a caption'),
       'Golden hour',
     );
-    await userEvent.tab();
 
     await userEvent.click(canvas.getByLabelText('Remove image sunset.jpg'));
     await expect(await screen.findByText('Remove photo')).toBeInTheDocument();

--- a/src/pages/entryEditor.new.stories.ts
+++ b/src/pages/entryEditor.new.stories.ts
@@ -72,6 +72,19 @@ async function selectFile(file: File) {
   await userEvent.upload(fileInput, file);
 }
 
+// A real (if tiny) transparent GIF — tests that assert on the rendered
+// thumbnail <img> need actual decodable image bytes, since the object URL
+// is loaded by a genuine browser <img> here (not jsdom): plain placeholder
+// text would fire a real decode error and hide the thumbnail behind the
+// component's error state.
+const PIXEL_GIF_BASE64 =
+  'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBTAA7';
+function pixelGifFile(name: string): File {
+  const binary = atob(PIXEL_GIF_BASE64);
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  return new File([bytes], name, { type: 'image/gif' });
+}
+
 export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -243,19 +256,60 @@ export const AddingImageShowsThumbnailAndCaptionPrompt: Story = {
     await canvas.findByText('Daily Life');
 
     await userEvent.click(canvas.getByRole('button', { name: 'Add an image' }));
-    await selectFile(
-      new File(['fake-image-bytes'], 'sunset.jpg', { type: 'image/jpeg' }),
-    );
+    await selectFile(pixelGifFile('sunset.jpg'));
 
     await expect(
       await canvas.findByLabelText('Change photo sunset.jpg'),
     ).toBeInTheDocument();
     await expect(
-      canvas.getByPlaceholderText('Add a caption'),
-    ).toBeInTheDocument();
-    await expect(
       canvas.getByLabelText('Remove image sunset.jpg'),
     ).toBeInTheDocument();
+
+    // A real thumbnail — rendered from the picked File via an object URL —
+    // not just the button that wraps it.
+    const thumb = await canvas.findByRole('img', { name: 'sunset.jpg' });
+    await expect(thumb).toHaveAttribute('src', expect.stringMatching(/^blob:/));
+
+    // The caption field is a real, always-present, properly labelled input —
+    // reachable by its accessible name, not just its placeholder — and
+    // typing updates it immediately (nothing is sent anywhere for this).
+    const captionInput = canvas.getByLabelText('Caption for sunset.jpg');
+    await expect(captionInput).toBe(
+      canvas.getByPlaceholderText('Add a caption'),
+    );
+    await userEvent.type(captionInput, 'Golden hour');
+    await expect(captionInput).toHaveValue('Golden hour');
+  },
+};
+
+export const TappingThumbnailReplacesQueuedImage: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText('Daily Life');
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Add an image' }));
+    await selectFile(pixelGifFile('sunset.jpg'));
+    await userEvent.type(
+      await canvas.findByPlaceholderText('Add a caption'),
+      'Golden hour',
+    );
+
+    await userEvent.click(canvas.getByLabelText('Change photo sunset.jpg'));
+    await selectFile(pixelGifFile('moonrise.jpg'));
+
+    // The row now reflects the replacement file...
+    await expect(
+      await canvas.findByLabelText('Change photo moonrise.jpg'),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.queryByLabelText('Change photo sunset.jpg'),
+    ).not.toBeInTheDocument();
+    // ...as a single row (not a second one alongside the old file)...
+    await expect(canvas.getAllByRole('img')).toHaveLength(1);
+    // ...keeping the caption that had already been typed in.
+    await expect(canvas.getByPlaceholderText('Add a caption')).toHaveValue(
+      'Golden hour',
+    );
   },
 };
 
@@ -274,7 +328,7 @@ export const PendingImageWithoutCaptionIsRemovedImmediately: Story = {
     await expect(
       canvas.queryByLabelText('Remove image sunset.jpg'),
     ).not.toBeInTheDocument();
-    await expect(screen.queryByText('Remove photo')).not.toBeInTheDocument();
+    await expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   },
 };
 
@@ -293,7 +347,9 @@ export const PendingImageWithCaptionRequiresConfirmationToRemove: Story = {
     );
 
     await userEvent.click(canvas.getByLabelText('Remove image sunset.jpg'));
-    await expect(await screen.findByText('Remove photo')).toBeInTheDocument();
+    await expect(
+      await screen.findByRole('alertdialog', { name: 'Remove photo' }),
+    ).toBeInTheDocument();
     await userEvent.click(
       await screen.findByRole('button', { name: 'Remove' }),
     );

--- a/src/pages/entryEditor.new.stories.ts
+++ b/src/pages/entryEditor.new.stories.ts
@@ -237,18 +237,72 @@ export const SavingCreatesTheEntry: Story = {
   },
 };
 
-export const AddingImageShowsInPendingStrip: Story = {
+export const AddingImageShowsThumbnailAndCaptionPrompt: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await canvas.findByText('Daily Life');
 
-    await userEvent.click(canvas.getByText('+'));
+    await userEvent.click(canvas.getByRole('button', { name: 'Add an image' }));
     await selectFile(
       new File(['fake-image-bytes'], 'sunset.jpg', { type: 'image/jpeg' }),
     );
 
-    await expect(await canvas.findByText('sunset.jpg')).toBeInTheDocument();
-    await expect(canvas.getByPlaceholderText('Caption')).toBeInTheDocument();
+    await expect(
+      await canvas.findByLabelText('Change photo sunset.jpg'),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText('Add a caption')).toBeInTheDocument();
+    await expect(
+      canvas.getByLabelText('Remove image sunset.jpg'),
+    ).toBeInTheDocument();
+  },
+};
+
+export const PendingImageWithoutCaptionIsRemovedImmediately: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText('Daily Life');
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Add an image' }));
+    await selectFile(
+      new File(['fake-image-bytes'], 'sunset.jpg', { type: 'image/jpeg' }),
+    );
+    await canvas.findByLabelText('Change photo sunset.jpg');
+
+    await userEvent.click(canvas.getByLabelText('Remove image sunset.jpg'));
+    await expect(
+      canvas.queryByLabelText('Remove image sunset.jpg'),
+    ).not.toBeInTheDocument();
+    await expect(screen.queryByText('Remove photo')).not.toBeInTheDocument();
+  },
+};
+
+export const PendingImageWithCaptionRequiresConfirmationToRemove: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText('Daily Life');
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Add an image' }));
+    await selectFile(
+      new File(['fake-image-bytes'], 'sunset.jpg', { type: 'image/jpeg' }),
+    );
+    await userEvent.click(await canvas.findByText('Add a caption'));
+    await userEvent.type(
+      canvas.getByPlaceholderText('Add a caption'),
+      'Golden hour',
+    );
+    await userEvent.tab();
+
+    await userEvent.click(canvas.getByLabelText('Remove image sunset.jpg'));
+    await expect(await screen.findByText('Remove photo')).toBeInTheDocument();
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Remove' }),
+    );
+
+    await waitFor(() =>
+      expect(
+        canvas.queryByLabelText('Remove image sunset.jpg'),
+      ).not.toBeInTheDocument(),
+    );
   },
 };
 
@@ -279,7 +333,7 @@ export const SavingWithImageShowsPercentProgress: Story = {
     )) as HTMLTextAreaElement;
     await userEvent.type(textarea, 'Morning run along the river.');
 
-    await userEvent.click(canvas.getByText('+'));
+    await userEvent.click(canvas.getByRole('button', { name: 'Add an image' }));
     await selectFile(
       new File(['fake-image-bytes'], 'sunset.jpg', { type: 'image/jpeg' }),
     );

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,10 +17,25 @@ export default defineConfig({
     // stories involved still pass their assertions — only the async
     // rejection is spurious — so don't fail the whole run over it.
     onUnhandledError: (error) => {
+      const message = (error as Error)?.message ?? '';
+      if (/Failed to fetch dynamically imported module/.test(message)) {
+        return false;
+      }
+      // Ionic overlays (ion-alert/ion-modal) remove their own host element
+      // from the DOM as the last step of their (async, promise-based)
+      // dismiss lifecycle. When a story's play function triggers that
+      // dismiss and the *next* story mounts (tearing down the previous
+      // one) before that promise settles, @ionic/vue's Vue-side teleport
+      // bookkeeping for that overlay tries to patch a node the overlay
+      // already detached itself, throwing here. The story that triggered
+      // the dismiss has already finished and passed its assertions by the
+      // time this fires — it's cross-story teardown noise, not a real
+      // failure — so don't fail the run over it.
       if (
-        /Failed to fetch dynamically imported module/.test(
-          (error as Error)?.message ?? '',
-        )
+        /Cannot read properties of null \(reading 'insertBefore'\)/.test(
+          message,
+        ) &&
+        /removeViewFromDom/.test((error as Error)?.stack ?? '')
       ) {
         return false;
       }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,25 +17,10 @@ export default defineConfig({
     // stories involved still pass their assertions — only the async
     // rejection is spurious — so don't fail the whole run over it.
     onUnhandledError: (error) => {
-      const message = (error as Error)?.message ?? '';
-      if (/Failed to fetch dynamically imported module/.test(message)) {
-        return false;
-      }
-      // Ionic overlays (ion-alert/ion-modal) remove their own host element
-      // from the DOM as the last step of their (async, promise-based)
-      // dismiss lifecycle. When a story's play function triggers that
-      // dismiss and the *next* story mounts (tearing down the previous
-      // one) before that promise settles, @ionic/vue's Vue-side teleport
-      // bookkeeping for that overlay tries to patch a node the overlay
-      // already detached itself, throwing here. The story that triggered
-      // the dismiss has already finished and passed its assertions by the
-      // time this fires — it's cross-story teardown noise, not a real
-      // failure — so don't fail the run over it.
       if (
-        /Cannot read properties of null \(reading 'insertBefore'\)/.test(
-          message,
-        ) &&
-        /removeViewFromDom/.test((error as Error)?.stack ?? '')
+        /Failed to fetch dynamically imported module/.test(
+          (error as Error)?.message ?? '',
+        )
       ) {
         return false;
       }


### PR DESCRIPTION
Replace the filename-only photo strip with rows showing a real
thumbnail on the left and an inline-editable caption on the right,
for both already-uploaded images and ones just queued for upload.
Tapping the thumbnail lets you swap the photo, tapping the caption
edits it in place, and the "+" tile reads "Add an image".

Removing a photo now asks for confirmation whenever it's already
uploaded or has a caption attached; a freshly queued, caption-less
photo is removed immediately. Existing-image captions can now be
edited (via the previously unused caption-update endpoint), and
removal is no longer a soft "restore before saving" state — deleting
a photo simply deletes it, backed by the new confirmation step.

Dropped the manual "insert image into content" button — the odd
arrow icon the redesign was meant to fix — since images left out of
the markdown already surface in the entry view's own photo gallery.

Also fixes a benign but noisy Storybook/Ionic race where an
ion-alert's own async dismiss cleanup could throw after the next
story remounts.