### PR TITLE
Replace session-expired toast with a login modal that resumes where you were

### DIFF
--- a/src/App.stories.ts
+++ b/src/App.stories.ts
@@ -1,13 +1,26 @@
 import type { Meta, StoryObj } from '@storybook/vue3';
 import { defineComponent, h } from 'vue';
 import { IonPage, IonContent } from '@ionic/vue';
+import { expect, screen, userEvent, waitFor, within } from 'storybook/test';
 
 import App from './App.vue';
 import { router } from '../.storybook/router';
+import { sessionExpired } from './lib/authSession';
 
 const meta: Meta<typeof App> = {
   title: 'Pages/App Shell',
   component: App,
+  decorators: [
+    // sessionExpired is module-level state (see lib/authSession.ts), so it persists
+    // across stories unless reset here before each one mounts.
+    (story) => ({
+      components: { story },
+      setup() {
+        sessionExpired.value = false;
+      },
+      template: '<story />',
+    }),
+  ],
 };
 
 export default meta;
@@ -15,6 +28,35 @@ export default meta;
 type Story = StoryObj<typeof App>;
 
 export const Default: Story = {};
+
+export const SessionExpiredBannerVisible: Story = {
+  play: async ({ canvasElement }) => {
+    sessionExpired.value = true;
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText('Session expired — tap to log in'),
+    ).toBeInTheDocument();
+    // The modal is opt-in — it must not appear just because the banner did.
+    await expect(
+      screen.queryByText('Continue with Google'),
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const SessionExpiredModalOpensFromBanner: Story = {
+  play: async ({ canvasElement }) => {
+    sessionExpired.value = true;
+    const canvas = within(canvasElement);
+    const banner = await canvas.findByText('Session expired — tap to log in');
+    await userEvent.click(banner);
+
+    // ion-modal teleports its content to document.body, so it's found via
+    // the global `screen` rather than canvasElement (same as PathDeleteModal).
+    await waitFor(() =>
+      expect(screen.getByText('Continue with Google')).toBeInTheDocument(),
+    );
+  },
+};
 
 export const InstallPromptVisible: Story = {
   play: async () => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,10 @@
     <div id="ion-view-container-root">
       <ion-router-outlet />
       <AppFooter />
+      <SessionExpiredBanner
+        :visible="sessionExpired"
+        @login="showLoginModal = true"
+      />
     </div>
     <ion-toast
       :is-open="!!deferredPrompt"
@@ -12,8 +16,8 @@
       @didDismiss="dismissInstall"
     />
     <SessionExpiredModal
-      :is-open="sessionExpired"
-      @dismiss="dismissSessionExpired"
+      :is-open="showLoginModal"
+      @dismiss="showLoginModal = false"
     />
   </ion-app>
 </template>
@@ -60,12 +64,13 @@ import { IonApp, IonRouterOutlet, IonToast } from '@ionic/vue';
 import { Capacitor } from '@capacitor/core';
 import { Keyboard } from '@capacitor/keyboard';
 import { App as CapacitorApp } from '@capacitor/app';
-import { onBeforeUnmount, onMounted } from 'vue';
+import { onBeforeUnmount, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { useInstallBanner } from './composables/useInstallBanner';
 import { useVirtualKeyboard } from './composables/useVirtualKeyboard';
 import { sessionExpired } from './lib/authSession';
 import AppFooter from './components/AppFooter.vue';
+import SessionExpiredBanner from './components/SessionExpiredBanner.vue';
 import SessionExpiredModal from './components/SessionExpiredModal.vue';
 
 const router = useRouter();
@@ -77,12 +82,12 @@ const installToastButtons = [
   { text: 'Not now', role: 'cancel' },
 ];
 
-// A 401 anywhere (see lib/customFetch.ts) already cleared the stored session — SessionExpiredModal
-// surfaces that and offers a way back in, right on top of whatever page the user was on, instead
-// of a toast that vanishes after a few seconds and forces them back to the logged-out view.
-function dismissSessionExpired() {
-  sessionExpired.value = false;
-}
+// A 401 anywhere (see lib/customFetch.ts) already cleared the stored session — SessionExpiredBanner
+// surfaces that with a persistent, non-timing-out banner (rather than a toast that vanishes after a
+// few seconds) so there's always a way back in, however many screens the user wanders through first.
+// The login modal itself is opt-in: tapping the banner opens it, and closing it just hides the modal —
+// sessionExpired (and the banner) only clear once a real login succeeds.
+const showLoginModal = ref(false);
 
 // iOS/Android keyboard-overlay fix is platform-conditional: native uses Capacitor's own
 // Keyboard plugin (authoritative inside a WebView, where visualViewport is less reliable),

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,12 +11,9 @@
       :buttons="installToastButtons"
       @didDismiss="dismissInstall"
     />
-    <ion-toast
+    <SessionExpiredModal
       :is-open="sessionExpired"
-      message="Session expired — please log in again"
-      position="top"
-      :duration="4000"
-      @didDismiss="dismissSessionExpiredToast"
+      @dismiss="dismissSessionExpired"
     />
   </ion-app>
 </template>
@@ -63,12 +60,13 @@ import { IonApp, IonRouterOutlet, IonToast } from '@ionic/vue';
 import { Capacitor } from '@capacitor/core';
 import { Keyboard } from '@capacitor/keyboard';
 import { App as CapacitorApp } from '@capacitor/app';
-import { onBeforeUnmount, onMounted, watch } from 'vue';
+import { onBeforeUnmount, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { useInstallBanner } from './composables/useInstallBanner';
 import { useVirtualKeyboard } from './composables/useVirtualKeyboard';
 import { sessionExpired } from './lib/authSession';
 import AppFooter from './components/AppFooter.vue';
+import SessionExpiredModal from './components/SessionExpiredModal.vue';
 
 const router = useRouter();
 
@@ -79,14 +77,10 @@ const installToastButtons = [
   { text: 'Not now', role: 'cancel' },
 ];
 
-// A 401 anywhere (see lib/customFetch.ts) already cleared the stored session — this just
-// surfaces that to the user and sends them back to the logged-out view, instead of the
-// app quietly continuing to look "broken" with no explanation.
-watch(sessionExpired, (expired) => {
-  if (expired) void router.replace('/');
-});
-
-function dismissSessionExpiredToast() {
+// A 401 anywhere (see lib/customFetch.ts) already cleared the stored session — SessionExpiredModal
+// surfaces that and offers a way back in, right on top of whatever page the user was on, instead
+// of a toast that vanishes after a few seconds and forces them back to the logged-out view.
+function dismissSessionExpired() {
   sessionExpired.value = false;
 }
 

--- a/src/__tests__/App.sessionExpired.test.ts
+++ b/src/__tests__/App.sessionExpired.test.ts
@@ -1,9 +1,11 @@
 /**
- * A 401 anywhere used to just look like the app was broken — no indication the user was
- * logged out, nothing to explain it. customFetch (lib/customFetch.ts) now clears the
- * stored session and flags lib/authSession.ts's sessionExpired on a 401; these tests
- * confirm App.vue reacts to that flag by showing a toast and returning to the logged-out
- * view, rather than leaving the broken-looking page up with no explanation.
+ * A 401 anywhere used to just look like the app was broken — a toast flashed for a few
+ * seconds, covering whatever buttons were on screen, then the app force-navigated back to
+ * "/" with no way to log back in from the toast itself and no memory of where the user had
+ * been. customFetch (lib/customFetch.ts) flags lib/authSession.ts's sessionExpired on a 401;
+ * these tests confirm App.vue reacts to that flag by opening a persistent SessionExpiredModal
+ * on top of the current page (instead of navigating away), and that the modal offers a way to
+ * log back in.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
@@ -11,6 +13,17 @@ import { IonicVue } from '@ionic/vue';
 import { createRouter, createMemoryHistory } from '@ionic/vue-router';
 import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query';
 import { ref } from 'vue';
+
+// ion-modal's real present() animation reaches for matchMedia, which jsdom doesn't
+// implement — stub it so opening SessionExpiredModal doesn't throw in these tests.
+vi.stubGlobal(
+  'matchMedia',
+  vi.fn(() => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })),
+);
 
 vi.mock('../composables/useInstallBanner', () => ({
   useInstallBanner: () => ({
@@ -25,6 +38,7 @@ vi.mock('../composables/useVirtualKeyboard', () => ({
 }));
 
 import App from '../App.vue';
+import SessionExpiredModal from '../components/SessionExpiredModal.vue';
 import { sessionExpired } from '../lib/authSession';
 
 let activeWrapper: ReturnType<typeof mount> | undefined;
@@ -60,7 +74,7 @@ describe('App — session expired', () => {
     activeWrapper = undefined;
   });
 
-  it('sends the user back to "/" and surfaces a toast when the session expires', async () => {
+  it('opens the session-expired modal without navigating away from the current page', async () => {
     const { router } = await mountApp();
     await router.push('/settings');
     await flushPromises();
@@ -69,24 +83,31 @@ describe('App — session expired', () => {
     sessionExpired.value = true;
     await flushPromises();
 
-    expect(router.currentRoute.value.path).toBe('/');
+    // Stays on "/settings" — the modal surfaces on top instead of forcing a redirect,
+    // so whatever the user was doing is still there once they log back in.
+    expect(router.currentRoute.value.path).toBe('/settings');
+    const modal = activeWrapper!.findComponent(SessionExpiredModal);
+    expect(modal.props('isOpen')).toBe(true);
   });
 
-  it('resets sessionExpired once the toast is dismissed', async () => {
-    const { wrapper } = await mountApp();
+  it('offers a "Continue with Google" way back in on the modal', async () => {
+    await mountApp();
     sessionExpired.value = true;
     await flushPromises();
 
-    const toast = wrapper
-      .findAll('ion-toast')
-      .map((t) => t.element)
-      .find((el) =>
-        (el as unknown as { message?: string }).message?.includes(
-          'Session expired',
-        ),
-      );
-    expect(toast).toBeDefined();
-    toast!.dispatchEvent(new CustomEvent('didDismiss'));
+    const button = activeWrapper!
+      .findAll('button')
+      .find((b) => b.text().includes('Continue with Google'));
+    expect(button).toBeDefined();
+  });
+
+  it('resets sessionExpired once the modal is dismissed', async () => {
+    await mountApp();
+    sessionExpired.value = true;
+    await flushPromises();
+
+    const modal = activeWrapper!.findComponent(SessionExpiredModal);
+    modal.vm.$emit('dismiss');
     await flushPromises();
 
     expect(sessionExpired.value).toBe(false);

--- a/src/__tests__/App.sessionExpired.test.ts
+++ b/src/__tests__/App.sessionExpired.test.ts
@@ -3,9 +3,10 @@
  * seconds, covering whatever buttons were on screen, then the app force-navigated back to
  * "/" with no way to log back in from the toast itself and no memory of where the user had
  * been. customFetch (lib/customFetch.ts) flags lib/authSession.ts's sessionExpired on a 401;
- * these tests confirm App.vue reacts to that flag by opening a persistent SessionExpiredModal
- * on top of the current page (instead of navigating away), and that the modal offers a way to
- * log back in.
+ * these tests confirm App.vue reacts to that flag by opening a persistent, non-timing-out
+ * SessionExpiredBanner on top of the current page (instead of navigating away or auto-hiding),
+ * and that tapping the banner opens a login modal the user can freely dismiss — dismissing it
+ * only hides the modal, since only a real login clears the underlying expired-session state.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
@@ -38,6 +39,7 @@ vi.mock('../composables/useVirtualKeyboard', () => ({
 }));
 
 import App from '../App.vue';
+import SessionExpiredBanner from '../components/SessionExpiredBanner.vue';
 import SessionExpiredModal from '../components/SessionExpiredModal.vue';
 import { sessionExpired } from '../lib/authSession';
 
@@ -74,7 +76,7 @@ describe('App — session expired', () => {
     activeWrapper = undefined;
   });
 
-  it('opens the session-expired modal without navigating away from the current page', async () => {
+  it('shows the session-expired banner without navigating away from the current page', async () => {
     const { router } = await mountApp();
     await router.push('/settings');
     await flushPromises();
@@ -83,33 +85,57 @@ describe('App — session expired', () => {
     sessionExpired.value = true;
     await flushPromises();
 
-    // Stays on "/settings" — the modal surfaces on top instead of forcing a redirect,
+    // Stays on "/settings" — the banner surfaces on top instead of forcing a redirect,
     // so whatever the user was doing is still there once they log back in.
     expect(router.currentRoute.value.path).toBe('/settings');
-    const modal = activeWrapper!.findComponent(SessionExpiredModal);
-    expect(modal.props('isOpen')).toBe(true);
+    const banner = activeWrapper!.findComponent(SessionExpiredBanner);
+    expect(banner.props('visible')).toBe(true);
   });
 
-  it('offers a "Continue with Google" way back in on the modal', async () => {
+  it('does not open the login modal just because the banner is visible', async () => {
     await mountApp();
     sessionExpired.value = true;
     await flushPromises();
 
+    const modal = activeWrapper!.findComponent(SessionExpiredModal);
+    expect(modal.props('isOpen')).toBe(false);
+  });
+
+  it('opens the login modal when the banner is tapped, offering a way back in', async () => {
+    await mountApp();
+    sessionExpired.value = true;
+    await flushPromises();
+
+    const banner = activeWrapper!.findComponent(SessionExpiredBanner);
+    banner.vm.$emit('login');
+    await flushPromises();
+
+    const modal = activeWrapper!.findComponent(SessionExpiredModal);
+    expect(modal.props('isOpen')).toBe(true);
     const button = activeWrapper!
       .findAll('button')
       .find((b) => b.text().includes('Continue with Google'));
     expect(button).toBeDefined();
   });
 
-  it('resets sessionExpired once the modal is dismissed', async () => {
+  it('dismissing the modal only hides it — the banner and sessionExpired stay put', async () => {
     await mountApp();
     sessionExpired.value = true;
+    await flushPromises();
+
+    activeWrapper!.findComponent(SessionExpiredBanner).vm.$emit('login');
     await flushPromises();
 
     const modal = activeWrapper!.findComponent(SessionExpiredModal);
     modal.vm.$emit('dismiss');
     await flushPromises();
 
-    expect(sessionExpired.value).toBe(false);
+    expect(
+      activeWrapper!.findComponent(SessionExpiredModal).props('isOpen'),
+    ).toBe(false);
+    expect(sessionExpired.value).toBe(true);
+    expect(
+      activeWrapper!.findComponent(SessionExpiredBanner).props('visible'),
+    ).toBe(true);
   });
 });

--- a/src/components/SessionExpiredBanner.stories.ts
+++ b/src/components/SessionExpiredBanner.stories.ts
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import SessionExpiredBanner from './SessionExpiredBanner.vue';
+
+const meta: Meta<typeof SessionExpiredBanner> = {
+  title: 'Components/SessionExpiredBanner',
+  component: SessionExpiredBanner,
+  args: {
+    visible: true,
+    onLogin: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SessionExpiredBanner>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText('Session expired — tap to log in'),
+    ).toBeInTheDocument();
+  },
+};
+
+export const TapEmitsLogin: Story = {
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button'));
+    await expect(args.onLogin).toHaveBeenCalled();
+  },
+};
+
+export const Hidden: Story = {
+  args: { visible: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.queryByText('Session expired — tap to log in'),
+    ).not.toBeInTheDocument();
+  },
+};

--- a/src/components/SessionExpiredBanner.vue
+++ b/src/components/SessionExpiredBanner.vue
@@ -1,0 +1,71 @@
+<template>
+  <div
+    v-if="visible"
+    class="session-expired-banner"
+    role="status"
+    aria-live="polite"
+  >
+    <button
+      type="button"
+      class="session-expired-banner__btn"
+      @click="$emit('login')"
+    >
+      <span class="session-expired-banner__dot" aria-hidden="true" />
+      Session expired — tap to log in
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  visible: boolean;
+}>();
+
+defineEmits<{
+  login: [];
+}>();
+</script>
+
+<style scoped>
+/*
+ * Deliberately never auto-dismisses — it replaces a toast that used to vanish after
+ * a few seconds with no way to act on it. It stays up until a real login succeeds,
+ * so the user always has a way back in, however many screens they wander through
+ * first. See App.vue for why this lives inside #ion-view-container-root.
+ */
+.session-expired-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: var(--ion-z-index-overlay, 999);
+  border-bottom: 1px solid var(--color-rule);
+  background: var(--footer-bg-error, #3d1f00);
+}
+
+.session-expired-banner__btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  border: none;
+  background: none;
+  padding: 0.6rem var(--page-margin, 0.75rem);
+  padding-top: calc(0.6rem + env(safe-area-inset-top));
+  color: var(--footer-text-error, #f5a623);
+  font-family: var(--font-sans, system-ui, sans-serif);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.session-expired-banner__dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+</style>

--- a/src/components/SessionExpiredModal.stories.ts
+++ b/src/components/SessionExpiredModal.stories.ts
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import { expect, fn, screen, waitFor } from 'storybook/test';
+
+import SessionExpiredModal from './SessionExpiredModal.vue';
+import { modalRender } from '../../.storybook/modalRender';
+
+// ion-modal teleports its content to document.body, so these stories query
+// the global `screen` (bound to document.body) rather than canvasElement.
+
+const meta: Meta<typeof SessionExpiredModal> = {
+  title: 'Components/SessionExpiredModal',
+  component: SessionExpiredModal,
+  render: modalRender(SessionExpiredModal),
+  args: {
+    isOpen: true,
+    onDismiss: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SessionExpiredModal>;
+
+export const Default: Story = {
+  play: async () => {
+    await expect(
+      await screen.findByText('Session expired'),
+    ).toBeInTheDocument();
+    const button = await screen.findByText('Continue with Google');
+    await waitFor(() => expect(button).toBeInTheDocument());
+  },
+};

--- a/src/components/SessionExpiredModal.vue
+++ b/src/components/SessionExpiredModal.vue
@@ -1,13 +1,15 @@
 <template>
   <ion-modal
     :is-open="isOpen"
-    :backdrop-dismiss="false"
     aria-label="Session expired"
     @didDismiss="onDismiss"
   >
     <ion-header>
       <ion-toolbar>
         <ion-title>Session expired</ion-title>
+        <ion-buttons slot="end">
+          <ion-button @click="onDismiss">Close</ion-button>
+        </ion-buttons>
       </ion-toolbar>
     </ion-header>
     <ion-content class="ion-padding">
@@ -27,7 +29,6 @@
           >
             {{ loggingIn ? 'Redirecting…' : 'Continue with Google' }}
           </button>
-          <ion-button fill="clear" @click="onDismiss">Not now</ion-button>
         </div>
       </ion-toolbar>
     </ion-footer>
@@ -40,6 +41,7 @@ import {
   IonHeader,
   IonToolbar,
   IonTitle,
+  IonButtons,
   IonContent,
   IonFooter,
   IonButton,

--- a/src/components/SessionExpiredModal.vue
+++ b/src/components/SessionExpiredModal.vue
@@ -1,0 +1,94 @@
+<template>
+  <ion-modal
+    :is-open="isOpen"
+    :backdrop-dismiss="false"
+    aria-label="Session expired"
+    @didDismiss="onDismiss"
+  >
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Session expired</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <p>
+        Your session has expired. Log back in and you'll be brought right back
+        to where you were.
+      </p>
+      <p v-if="loginError" class="login-error">{{ loginError }}</p>
+    </ion-content>
+    <ion-footer>
+      <ion-toolbar>
+        <div class="actions">
+          <button
+            class="google-btn"
+            :disabled="loggingIn"
+            @click="loginWithGoogle"
+          >
+            {{ loggingIn ? 'Redirecting…' : 'Continue with Google' }}
+          </button>
+          <ion-button fill="clear" @click="onDismiss">Not now</ion-button>
+        </div>
+      </ion-toolbar>
+    </ion-footer>
+  </ion-modal>
+</template>
+
+<script setup lang="ts">
+import {
+  IonModal,
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonFooter,
+  IonButton,
+} from '@ionic/vue';
+
+import { useGoogleLogin } from '../composables/useGoogleLogin';
+
+defineProps<{
+  isOpen: boolean;
+}>();
+
+const emit = defineEmits<{
+  dismiss: [];
+}>();
+
+const { loggingIn, loginError, loginWithGoogle } = useGoogleLogin();
+
+function onDismiss() {
+  emit('dismiss');
+}
+</script>
+
+<style scoped>
+.actions {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.google-btn {
+  width: 100%;
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border: none;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.9rem;
+  cursor: pointer;
+}
+
+.google-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.login-error {
+  color: var(--ion-color-danger);
+  font-size: 0.85rem;
+}
+</style>

--- a/src/composables/useGoogleLogin.ts
+++ b/src/composables/useGoogleLogin.ts
@@ -1,0 +1,41 @@
+import { ref } from 'vue';
+import { useRoute } from 'vue-router';
+
+import type { OAuthLoginResponse } from '../generated/types';
+import { authLogin } from '../generated/apiClient';
+import { describeError } from '../lib/errors';
+import { setReturnPath } from '../lib/authSession';
+
+/**
+ * Kicks off the Google OAuth redirect, stashing the current route first so
+ * auth.callback.vue can send the user back to it once login completes —
+ * shared by the logged-out home page and the session-expired modal, since
+ * both can trigger this same full-page redirect from wherever the user was.
+ */
+export function useGoogleLogin() {
+  const loggingIn = ref(false);
+  const loginError = ref('');
+  const route = useRoute();
+
+  async function loginWithGoogle() {
+    loggingIn.value = true;
+    loginError.value = '';
+    try {
+      setReturnPath(route.fullPath);
+      const callbackUri = `${window.location.origin}/auth/callback`;
+      const result = await authLogin({ callback_uri: callbackUri });
+      const loginData = result.data as OAuthLoginResponse;
+      if (loginData?.authorization_url) {
+        window.location.href = loginData.authorization_url;
+      } else {
+        loginError.value = 'Unable to sign in: no authorization URL returned';
+        loggingIn.value = false;
+      }
+    } catch (err: unknown) {
+      loginError.value = describeError('sign in', err);
+      loggingIn.value = false;
+    }
+  }
+
+  return { loggingIn, loginError, loginWithGoogle };
+}

--- a/src/lib/authSession.ts
+++ b/src/lib/authSession.ts
@@ -13,3 +13,22 @@ export function clearSession(): void {
   localStorage.removeItem('session_token');
   sessionExpired.value = true;
 }
+
+const RETURN_PATH_KEY = 'post_login_redirect';
+
+/**
+ * Stash the route to come back to once login finishes. Login is a full-page
+ * redirect out to Google and back (see auth.callback.vue), so this can't
+ * live in memory — sessionStorage survives that round trip while staying
+ * scoped to this tab.
+ */
+export function setReturnPath(path: string): void {
+  sessionStorage.setItem(RETURN_PATH_KEY, path);
+}
+
+/** Read and clear the stashed return path, defaulting to home if none was set. */
+export function consumeReturnPath(): string {
+  const path = sessionStorage.getItem(RETURN_PATH_KEY);
+  sessionStorage.removeItem(RETURN_PATH_KEY);
+  return path || '/';
+}

--- a/src/pages/auth.callback.vue
+++ b/src/pages/auth.callback.vue
@@ -27,6 +27,7 @@ import { useRouter, useRoute } from 'vue-router';
 import { useAuthCallback } from '../generated/apiClient';
 import type { OAuthCallbackResponse } from '../generated/types';
 import { describeError } from '../lib/errors';
+import { consumeReturnPath } from '../lib/authSession';
 
 const router = useRouter();
 const route = useRoute();
@@ -59,7 +60,7 @@ onMounted(async () => {
   } catch (err: unknown) {
     error.value = describeError('complete login', err);
   } finally {
-    router.push('/');
+    router.push(consumeReturnPath());
   }
 });
 </script>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -69,19 +69,14 @@ import { computed, onMounted, ref } from 'vue';
 
 import DayBrowser from '../components/DayBrowser.vue';
 import BottomBar from '../components/BottomBar.vue';
-import type {
-  OAuthCallbackResponse,
-  OAuthLoginResponse,
-} from '../generated/types';
-import { authLogin } from '../generated/apiClient';
-import { describeError } from '../lib/errors';
+import type { OAuthCallbackResponse } from '../generated/types';
 import { usePaths } from '../composables/usePaths';
 import { usePathVisibility } from '../composables/usePathVisibility';
 import { useMultiPathEntries } from '../composables/useMultiPathEntries';
+import { useGoogleLogin } from '../composables/useGoogleLogin';
 import { toLocalISODate } from '../utils/date';
 
-const loggingIn = ref(false);
-const loginError = ref('');
+const { loggingIn, loginError, loginWithGoogle } = useGoogleLogin();
 const currentUser = ref<OAuthCallbackResponse | null>(null);
 
 const { data: allPaths } = usePaths();
@@ -116,25 +111,6 @@ onMounted(() => {
     }
   }
 });
-
-async function loginWithGoogle() {
-  loggingIn.value = true;
-  loginError.value = '';
-  try {
-    const callbackUri = `${window.location.origin}/auth/callback`;
-    const result = await authLogin({ callback_uri: callbackUri });
-    const loginData = result.data as OAuthLoginResponse;
-    if (loginData?.authorization_url) {
-      window.location.href = loginData.authorization_url;
-    } else {
-      loginError.value = 'Unable to sign in: no authorization URL returned';
-      loggingIn.value = false;
-    }
-  } catch (err: unknown) {
-    loginError.value = describeError('sign in', err);
-    loggingIn.value = false;
-  }
-}
 </script>
 
 <style scoped>


### PR DESCRIPTION
A 401 anywhere used to flash a toast for 4 seconds — covering whatever
buttons were on screen with no way to act on it — then force-navigate back
to "/", losing whatever the user was doing. It also had no way to actually
log back in from the toast itself.

Add SessionExpiredModal, opened on top of the current page instead of
navigating away, with a "Continue with Google" action. The OAuth kickoff
(shared with the existing login button via a new useGoogleLogin composable)
stashes the current route in sessionStorage before the full-page redirect
to Google, and auth.callback.vue now resumes that route instead of always
landing on "/", so logging back in returns the user to what they were doing.