### PR TITLE
Fix MSW service worker 404 breaking Storybook stories on GitHub Pages

### DIFF
--- a/.storybook/preview.test.ts
+++ b/.storybook/preview.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Regression test for the GitHub Pages deploy: msw-storybook-addon's
+ * initialize() defaults to an absolute service-worker URL
+ * ('/mockServiceWorker.js'), which 404s once Storybook is served from a
+ * subpath (e.g. https://mjaquiery.github.io/paths-frontend/). That 404 makes
+ * MSW fail to register, which crashes every story render.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+const initialize = vi.fn();
+
+vi.mock('msw-storybook-addon', () => ({
+  initialize,
+  mswLoader: vi.fn(),
+}));
+
+describe('.storybook/preview', () => {
+  it('initializes MSW with a relative service-worker URL', async () => {
+    await import('./preview');
+
+    expect(initialize).toHaveBeenCalledTimes(1);
+    const [options] = initialize.mock.calls[0] as [
+      { serviceWorker?: { url?: string } },
+    ];
+    expect(options.serviceWorker?.url).toMatch(/^\.\//);
+  });
+});

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -17,7 +17,11 @@ import '../src/assets/design-f.css';
 import { handlers } from '../src/mocks/handlers';
 import { router, resetRouteLoader, setNavAlertSuppressed } from './router';
 
-initialize();
+// Default worker URL is absolute ('/mockServiceWorker.js'), which 404s once
+// Storybook is served from a subpath (e.g. the GitHub Pages deploy at
+// /paths-frontend/). A relative URL resolves against iframe.html's own
+// directory instead, so it works both at the root and under a subpath.
+initialize({ serviceWorker: { url: './mockServiceWorker.js' } });
 
 // Mirrors useDarkMode's logic: toggles the same class/attribute the real app uses.
 function applyTheme(theme: 'light' | 'dark') {


### PR DESCRIPTION
msw-storybook-addon's initialize() defaults to an absolute worker URL
('/mockServiceWorker.js'), which 404s once Storybook is deployed under
a subpath (https://mjaquiery.github.io/paths-frontend/). The failed
registration threw and crashed every story render, including the
App Shell story. Point it at a relative URL so it resolves against
iframe.html's own directory instead.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUi4ZbDK6TUXUrv1LrhuHR