### PR TITLE
Fix entry-delete redirect, not-found messaging, modal dismiss, and save navigation delay

### DIFF
--- a/src/__tests__/useRefreshStatus.test.ts
+++ b/src/__tests__/useRefreshStatus.test.ts
@@ -6,6 +6,7 @@ import {
   formatRelativeTime,
   useRefreshStatus,
 } from '../composables/useRefreshStatus';
+import { ApiError } from '../lib/customFetch';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -163,6 +164,30 @@ describe('useRefreshStatus', () => {
     expect(exposed.hasError.value).toBe(true);
     expect(exposed.statusType.value).toBe('error');
     expect(exposed.statusText.value).toBe('Unable to connect');
+
+    wrapper.unmount();
+  });
+
+  it('does not set hasError when an entry query 404s (entry not found, not offline)', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { wrapper, exposed } = mountWithStatus(queryClient);
+    await flushPromises();
+
+    // A deleted/nonexistent entry's detail query matches the same
+    // ['v1','paths',pathId,'entries',...] key prefix as the entry-list
+    // query this composable watches, so its 404 must not be mistaken for a
+    // connectivity failure.
+    await queryClient.prefetchQuery({
+      queryKey: ['v1', 'paths', 'p1', 'entries', 'e1'],
+      queryFn: () => Promise.reject(new ApiError(404, 'not found')),
+      retry: false,
+    });
+    await nextTick();
+
+    expect(exposed.hasError.value).toBe(false);
+    expect(exposed.statusType.value).toBe('ok');
 
     wrapper.unmount();
   });

--- a/src/components/PathBrowser.stories.ts
+++ b/src/components/PathBrowser.stories.ts
@@ -155,6 +155,21 @@ export const NoEntriesForSelectedPath: Story = {
   },
 };
 
+// A deleted path (or a stale/bad link) — distinct from a real path that
+// simply has no entries yet.
+export const PathNotFound: Story = {
+  args: { entries: [], pathNotFound: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(
+        "This path couldn't be found. It may have been deleted.",
+      ),
+    ).toBeInTheDocument();
+    await expect(canvas.queryByText('No entries yet.')).not.toBeInTheDocument();
+  },
+};
+
 // The expected case for this component — a followed path can easily
 // accumulate dozens of posts, unlike Day Browser's one-per-day-per-path.
 export const ManyEntries: Story = {

--- a/src/components/PathBrowser.vue
+++ b/src/components/PathBrowser.vue
@@ -18,6 +18,9 @@
         <ion-spinner name="crescent" aria-label="Loading entries" />
         <span>Loading entries…</span>
       </div>
+      <p v-else-if="pathNotFound" class="pb-empty">
+        This path couldn't be found. It may have been deleted.
+      </p>
       <template v-else-if="visibleEntries.length > 0">
         <div
           v-for="entry in visibleEntries"
@@ -90,6 +93,8 @@ const props = defineProps<{
   entries: EntryWithContent[];
   isLoading?: boolean;
   hasMore?: boolean;
+  /** The selected path isn't in the user's own path list — deleted, or a stale/bad link. */
+  pathNotFound?: boolean;
   /** When set, scrolls to and highlights the entry for this day once it renders. */
   centerDay?: string;
 }>();

--- a/src/components/PathDeleteModal.vue
+++ b/src/components/PathDeleteModal.vue
@@ -1,5 +1,10 @@
 <template>
-  <ion-modal :is-open="isOpen" aria-label="Delete Path" @didDismiss="onDismiss">
+  <ion-modal
+    :is-open="isOpen"
+    aria-label="Delete Path"
+    :backdrop-dismiss="!deleting"
+    @didDismiss="onDismiss"
+  >
     <ion-header>
       <ion-toolbar>
         <ion-title>Delete Path</ion-title>

--- a/src/components/PathFormModal.vue
+++ b/src/components/PathFormModal.vue
@@ -2,6 +2,7 @@
   <ion-modal
     :is-open="isOpen"
     :aria-label="path ? 'Edit Path' : 'New Path'"
+    :backdrop-dismiss="!saving"
     @didDismiss="onDismiss"
   >
     <div class="pf-header df-ui">

--- a/src/composables/useRefreshStatus.ts
+++ b/src/composables/useRefreshStatus.ts
@@ -1,6 +1,7 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { useIsFetching, useQueryClient } from '@tanstack/vue-query';
 import type { QueryCacheNotifyEvent } from '@tanstack/query-core';
+import { ApiError } from '../lib/customFetch';
 
 export type RefreshStatusType = 'ok' | 'fetching' | 'offline' | 'error';
 
@@ -91,7 +92,12 @@ export function useRefreshStatus() {
         event.action.type === 'error' ||
         event.query.state.status === 'error'
       ) {
-        hasError.value = true;
+        // A 404 means the entry/path genuinely doesn't exist (e.g. it was
+        // just deleted, or a stale link) — not a connectivity problem, so it
+        // shouldn't flip the app-wide "Unable to connect" indicator.
+        const err = event.query.state.error;
+        const isNotFound = err instanceof ApiError && err.status === 404;
+        if (!isNotFound) hasError.value = true;
       }
     });
   });

--- a/src/pages/entry.[pathId].[entryId].edit.vue
+++ b/src/pages/entry.[pathId].[entryId].edit.vue
@@ -342,11 +342,14 @@ async function submit() {
       },
     });
 
-    await queryClient.invalidateQueries({
+    // Navigate immediately — invalidation and draft cleanup don't need to
+    // block leaving the page, and awaiting them here made "Save" feel stuck
+    // for a full network round-trip after the entry was already saved.
+    router.push(entryViewLink.value);
+    void queryClient.invalidateQueries({
       queryKey: ['v1', 'paths', pathId, 'entries'],
     });
-    await clearDraft();
-    router.push(entryViewLink.value);
+    void clearDraft();
   } catch (err: unknown) {
     if (isApiErrorWithStatus(err, 409)) {
       conflictError.value =

--- a/src/pages/entry.[pathId].[entryId].vue
+++ b/src/pages/entry.[pathId].[entryId].vue
@@ -51,16 +51,21 @@
         </h1>
 
         <p v-if="deleteError" class="entry-error">{{ deleteError }}</p>
-        <p v-if="content === undefined" class="entry-body-placeholder">
-          Fetching…
+        <p v-if="entryNotFound" class="entry-body-placeholder">
+          This entry couldn't be found. It may have been deleted.
         </p>
-        <p v-else-if="!content" class="entry-body-placeholder">(no text)</p>
-        <MarkdownContent
-          v-else
-          class="entry-body"
-          :content="content"
-          :images="images"
-        />
+        <template v-else>
+          <p v-if="content === undefined" class="entry-body-placeholder">
+            Fetching…
+          </p>
+          <p v-else-if="!content" class="entry-body-placeholder">(no text)</p>
+          <MarkdownContent
+            v-else
+            class="entry-body"
+            :content="content"
+            :images="images"
+          />
+        </template>
 
         <template v-if="unreferencedImages.length > 0">
           <p class="entry-section-label">
@@ -132,7 +137,7 @@ import { usePaths } from '../composables/usePaths';
 import { usePathVisibility } from '../composables/usePathVisibility';
 import { useMultiPathEntries } from '../composables/useMultiPathEntries';
 import { useOnThisDay } from '../composables/useOnThisDay';
-import { describeError } from '../lib/errors';
+import { describeError, isApiErrorWithStatus } from '../lib/errors';
 import MarkdownContent from '../components/MarkdownContent.vue';
 import EntryImage from '../components/EntryImage.vue';
 import ImageLightbox from '../components/ImageLightbox.vue';
@@ -188,12 +193,16 @@ const canEdit = computed(
     path.value?.owner_user_id === currentUser.value.user_id,
 );
 
-const { data: entryData } = useGetEntry(pathId, entryId, {
+const { data: entryData, error: entryError } = useGetEntry(pathId, entryId, {
   query: { select: (r) => r.data as EntryContentResponse },
 });
 const { data: imagesData } = useListEntryImages(pathId, entryId, {
   query: { select: (r) => r.data as ImageResponse[] },
 });
+
+const entryNotFound = computed(() =>
+  isApiErrorWithStatus(entryError.value, 404),
+);
 
 const content = computed(() => entryData.value?.content);
 const images = computed(() => imagesData.value ?? []);
@@ -295,10 +304,13 @@ async function performDelete() {
   deleteError.value = '';
   try {
     await doDeleteEntry({ pathCode: pathId.value, entrySlug: entryId.value });
-    await queryClient.invalidateQueries({
+    // Navigate away before invalidating: this entry's own detail query
+    // shares the ['v1','paths',pathId,'entries',...] prefix, so an awaited
+    // invalidation here would refetch (and 404 on) the entry we just left.
+    goBack();
+    void queryClient.invalidateQueries({
       queryKey: ['v1', 'paths', pathId.value, 'entries'],
     });
-    goBack();
   } catch (err: unknown) {
     deleteError.value = describeError('delete entry', err);
   }

--- a/src/pages/entry.new.vue
+++ b/src/pages/entry.new.vue
@@ -296,11 +296,14 @@ async function submit() {
         images: pendingImages.value.map((img) => img.file),
       },
     });
-    await queryClient.invalidateQueries({
+    // Navigate immediately — invalidation and draft cleanup don't need to
+    // block leaving the page, and awaiting them here made "Save" feel stuck
+    // for a full network round-trip after the entry was already created.
+    goBack();
+    void queryClient.invalidateQueries({
       queryKey: ['v1', 'paths', selectedPathId.value, 'entries'],
     });
-    await clearDraft();
-    goBack();
+    void clearDraft();
   } catch (err: unknown) {
     error.value = describeError('create entry', err);
   }

--- a/src/pages/paths.loggedIn.stories.ts
+++ b/src/pages/paths.loggedIn.stories.ts
@@ -78,6 +78,22 @@ export const WriteEntryCarriesPathAndDay: Story = {
   },
 };
 
+// A deleted path (or a stale/bad link) linked to directly — e.g. from a
+// path label on an entry whose path no longer exists — should say so
+// clearly rather than silently looking like an empty path.
+export const PathNotFound: Story = {
+  loaders: [routeLoader('/paths?pathId=deleted-path')],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(
+        "This path couldn't be found. It may have been deleted.",
+        { exact: false },
+      ),
+    ).toBeInTheDocument();
+  },
+};
+
 export const CalendarIconNavigatesToDayBrowser: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/src/pages/paths.vue
+++ b/src/pages/paths.vue
@@ -8,6 +8,7 @@
         :entries="selectedPathEntries"
         :is-loading="selectedPathIsLoading"
         :has-more="selectedPathHasMore"
+        :path-not-found="selectedPathNotFound"
         :center-day="centerDay"
         @load-more="loadMore(selectedPathId)"
       />
@@ -40,7 +41,7 @@ import { toLocalISODate } from '../utils/date';
 const route = useRoute();
 const currentUser = ref<OAuthCallbackResponse | null>(null);
 
-const { data: allPaths } = usePaths();
+const { data: allPaths, isPending: pathsLoading } = usePaths();
 const { visiblePaths } = usePathVisibility(allPaths);
 
 const centerDay =
@@ -57,6 +58,16 @@ watch(
     }
   },
   { immediate: true },
+);
+
+// Checked against allPaths (not visiblePaths, which also excludes paths the
+// user has merely hidden) — a pathId absent from the user's own path list
+// entirely means deleted, or a stale/bad link, not a display preference.
+const selectedPathNotFound = computed(
+  () =>
+    !pathsLoading.value &&
+    !!selectedPathId.value &&
+    !allPaths.value?.some((p) => p.path_id === selectedPathId.value),
 );
 
 const selectedPathIds = computed(() =>


### PR DESCRIPTION
Deleting an entry awaited invalidateQueries (which refetches the entry's own
now-404ing detail query, since its key shares the entries-list prefix)
before navigating away, so a failed refetch could block the redirect and
strand the user on a dead entry page. Navigate first, invalidate in the
background.

A 404 on an entry/path query flipped the app-wide "Unable to connect"
indicator, indistinguishable from an actual network failure. Skip that for
404s specifically, and show a dedicated "entry couldn't be found" message
on the entry page itself.

PathFormModal and PathDeleteModal had no backdrop-dismiss guard, so
clicking outside while a save/delete was in flight silently closed the
modal. Disable backdrop dismiss while saving/deleting, matching the
pattern already used by SavingOverlay.

Both entry save flows awaited cache invalidation and draft cleanup before
navigating to the saved entry, adding a full network round-trip of visible
delay after the save had already completed. Navigate immediately and let
invalidation/cleanup run in the background.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Cc4TWUSWER3BhWKK6d5ncf