### PR TITLE
Add Phase 1 design doc: ETag-aware fetch layer + version-diff polling

### DIFF
--- a/design/phases/1_etag_conditional_caching.md
+++ b/design/phases/1_etag_conditional_caching.md
@@ -78,7 +78,11 @@ interface EtagRecord {
 }
 // Dexie table `etagCache`, keyed by url
 export async function getEtag(url: string): Promise<EtagRecord | undefined>;
-export async function setEtag(url: string, etag: string, body: unknown): Promise<void>;
+export async function setEtag(
+  url: string,
+  etag: string,
+  body: unknown,
+): Promise<void>;
 export async function clearEtags(): Promise<void>; // called from clearSession()
 ```
 

--- a/design/phases/1_etag_conditional_caching.md
+++ b/design/phases/1_etag_conditional_caching.md
@@ -1,0 +1,162 @@
+# Phase 1 — ETag-Aware Fetch Layer + Version-Diff Polling
+
+## Objective
+
+Make `customFetch.ts` conditional-GET aware — store an ETag + last body per
+URL, send `If-None-Match`, transparently resolve a `304` into the cached
+body — and replace `useMultiPathEntries`'s per-path 25s full-list poll with
+a single cheap bulk version-map poll that only triggers real refetches for
+entries whose version actually changed.
+
+## Why this exists
+
+- Backend Phase 5 (`paths` repo, `design/phases/5_etag_conditional_caching.md`)
+  adds ETag/304 support and a bulk versions endpoint; this phase consumes it.
+- The actual responsiveness/bandwidth cost today is in
+  `useMultiPathEntries.ts:56-68` — it refetches the full entry list for
+  every subscribed path every 25s regardless of whether anything changed.
+- Keeping the change inside the fetch layer makes it transparent to the
+  orval-generated hooks and existing composables: no changes needed to
+  `src/generated/apiClient.ts` (do-not-edit) or to individual `useX` call
+  sites outside `useMultiPathEntries`.
+
+## Scope
+
+### In scope
+
+1. `src/lib/etagStore.ts` (new): a small Dexie table (`{url, etag, body}`)
+   alongside the existing query-cache persister, with get/set/clear.
+2. `customFetch.ts` changes (`src/lib/customFetch.ts`):
+   - Before a GET request: look up the stored etag for the request URL,
+     attach `If-None-Match`.
+   - After the response: on `304`, return the stored body (still shaped as
+     `{data, status, headers}` per the existing contract, `status`
+     normalized to `200` for callers); on `200`, store the new etag + body,
+     return normally.
+   - Clear the etag cache on logout (existing 401 handler at
+     `customFetch.ts:112-116`, which calls `clearSession()`) to prevent
+     cross-account leakage in a shared browser. **Finding from this repo's
+     current code:** `clearSession()` (`src/lib/authSession.ts:11-15`)
+     clears `localStorage` only — it does not currently clear the Dexie
+     query-cache persister either, so this is a pre-existing gap, not just
+     a new risk this feature introduces. Wire etag-cache clearing into
+     `clearSession()` and flag the query-cache gap for a follow-up.
+   - XHR upload path (`customFetch.ts:121-157`) untouched — mutations, not
+     cacheable GETs.
+3. New composable `useEntryVersions` (or extend `useMultiPathEntries`):
+   polls the bulk versions endpoint (`GET /v1/entries/versions?path_ids=...`)
+   on the existing 25s interval; diffs the returned
+   `{path_id: {entry_id: edit_id}}` map against a locally held last-known
+   map; for entries whose `edit_id` changed, calls
+   `queryClient.invalidateQueries` on just those entry keys instead of the
+   whole list.
+4. Dexie schema version bump (new `etagCache` table) alongside the existing
+   `queryCache` table used by `queryPersister.ts`.
+
+### Out of scope (this phase)
+
+- Native `fetch()` browser HTTP caching. Explicit decision to keep this
+  app-level/explicit: Bearer-token auth on every request makes relying on
+  the browser's own HTTP cache behavior unreliable to depend on without
+  separate verification.
+- Changing `staleTime: Infinity` on `edit_id`-keyed content queries
+  (`useMultiPathEntries.ts:157-158`) — that pattern is already effectively
+  "immutable per version," and is complementary to (not replaced by) ETag
+  caching.
+- Applying etag handling to endpoints beyond the backend's pilot set (paths,
+  entries) until backend Phase 5 extends coverage.
+
+## Proposed implementation
+
+### `etagStore.ts`
+
+```ts
+interface EtagRecord {
+  url: string;
+  etag: string;
+  body: unknown;
+}
+// Dexie table `etagCache`, keyed by url
+export async function getEtag(url: string): Promise<EtagRecord | undefined>;
+export async function setEtag(url: string, etag: string, body: unknown): Promise<void>;
+export async function clearEtags(): Promise<void>; // called from clearSession()
+```
+
+### `customFetch.ts` (sketch, GET path only)
+
+```ts
+if (method === 'GET') {
+  const cached = await getEtag(url);
+  if (cached) headers['If-None-Match'] = cached.etag;
+}
+const response = await fetch(url, { ...opts, headers });
+if (response.status === 304 && cached) {
+  return { data: cached.body, status: 200, headers: response.headers };
+}
+const data = await response.json();
+const etag = response.headers.get('ETag');
+if (method === 'GET' && etag) await setEtag(url, etag, data);
+return { data, status: response.status, headers: response.headers };
+```
+
+### Version-diff polling
+
+Replace the per-path `queryFn: () => listEntries(pathId)` fan-out in
+`useMultiPathEntries.ts` with:
+
+1. One `useQuery` polling `getEntryVersions(pathIds)` every 25s (cheap,
+   small response).
+2. A diff step comparing the new map to the previous one (component-local
+   ref, not persisted — cold start after a page load always does a real
+   comparison against a fresh versions response).
+3. On diff, `queryClient.invalidateQueries({ queryKey: ['v1', 'entries', entryId] })`
+   for changed entries only — existing per-entry queries/composables pick up
+   the invalidation and refetch individually; no new fetch logic needed at
+   that layer.
+
+## Data model / storage impact
+
+New Dexie table `etagCache`. Requires a Dexie version bump in the schema
+used by `queryPersister.ts` — additive, no migration of existing data
+needed (the new table starts empty).
+
+## Testing plan
+
+Per this repo's convention: small test that fails on the bug, then confirms
+the fix — not manual screenshot loops.
+
+- Unit test for `customFetch`: mock `fetch` to return `304` with no body on
+  the second call for the same URL; assert the mutator returns the same
+  `data` as the first (`200`) call.
+- Unit test for `etagStore`: set/get/clear round-trip.
+- Unit test for the version-diff logic: given two version maps differing in
+  one entry, assert exactly that entry's query key is invalidated (and no
+  others).
+- Composable test for `useEntryVersions` against the backend's versions
+  endpoint contract (via the existing MSW mocking setup).
+
+## Acceptance criteria
+
+1. A second GET to an unchanged resource results in a `304` network
+   response and no response body, while the caller still receives the
+   correct data.
+2. Multi-path polling issues one versions request per tick instead of N
+   list requests, and only fetches full data for entries that actually
+   changed.
+3. Logging out and back in as a different user never surfaces the previous
+   user's cached body.
+4. No changes required to orval-generated code, or to `useX` call sites
+   outside `useMultiPathEntries`.
+
+## Risk notes
+
+1. Cache poisoning across accounts if `clearEtags()` isn't wired into every
+   logout path — same rigor needed as the (currently missing) query-cache
+   clear-on-logout; worth fixing both together.
+2. The stored-body cache can grow unbounded over a long session — reuse
+   whatever eviction/size policy (if any) governs `queryCache`, or cap
+   `etagCache` similarly.
+3. Cold start (browser restart) has no local version map for the diff step
+   — the first poll after load is always a real comparison against a fresh
+   versions response, which is correct but not optimized; test this path
+   explicitly so a bug there can't silently skip real changes.

--- a/schema/openapi.json
+++ b/schema/openapi.json
@@ -1,1983 +1,196 @@
 {
-  "openapi": "3.1.0",
-  "info": {
-    "title": "paths backend API",
-    "summary": "Path-centric backend API for Shared Journal PWA",
-    "version": "0.4.0"
-  },
-  "paths": {
-    "/health": {
-      "get": {
-        "tags": [
-          "health"
-        ],
-        "summary": "Health",
-        "operationId": "health",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HealthResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/paths": {
-      "get": {
-        "tags": [
-          "paths"
-        ],
-        "summary": "List Paths",
-        "operationId": "list_paths",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/PathResponse"
-                  },
-                  "type": "array",
-                  "title": "Response List Paths"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ]
-      },
-      "post": {
-        "tags": [
-          "paths"
-        ],
-        "summary": "Create Path",
-        "operationId": "create_path",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PathCreateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PathResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ]
-      }
-    },
-    "/v1/paths/{path_code}": {
-      "patch": {
-        "tags": [
-          "paths"
-        ],
-        "summary": "Update Path",
-        "operationId": "update_path",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "path_code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Path Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PathUpdateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PathResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "paths"
-        ],
-        "summary": "Delete Path",
-        "operationId": "delete_path",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "path_code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Path Code"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/paths/{path_code}/visibility": {
-      "patch": {
-        "tags": [
-          "paths"
-        ],
-        "summary": "Update Path Visibility",
-        "operationId": "update_path_visibility",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "path_code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Path Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PathVisibilityUpdateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PathResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/paths/{path_code}/entries": {
-      "get": {
-        "tags": [
-          "entries"
-        ],
-        "summary": "List Entries",
-        "operationId": "list_entries",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "path_code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Path Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/EntryResponse"
-                  },
-                  "title": "Response List Entries"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "entries"
-        ],
-        "summary": "Create Entry",
-        "operationId": "create_entry",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "path_code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Path Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_create_entry"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EntryResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/paths/{path_code}/entries/{entry_slug}": {
-      "get": {
-        "tags": [
-          "entries"
-        ],
-        "summary": "Get Entry",
-        "operationId": "get_entry",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "path_code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Path Code"
-            }
-          },
-          {
-            "name": "entry_slug",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Entry Slug"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EntryContentResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "entries"
-        ],
-        "summary": "Update Entry",
-        "operationId": "update_entry",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "path_code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Path Code"
-            }
-          },
-          {
-            "name": "entry_slug",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Entry Slug"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_update_entry"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EntryResponse"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Optimistic lock mismatch for expected_edit_id.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OptimisticLockHTTPErrorResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "entries"
-        ],
-        "summary": "Delete Entry",
-        "operationId": "delete_entry",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "path_code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Path Code"
-            }
-          },
-          {
-            "name": "entry_slug",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Entry Slug"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/paths/{path_code}/entries/{entry_slug}/images": {
-      "get": {
-        "tags": [
-          "entries"
-        ],
-        "summary": "List Entry Images",
-        "operationId": "list_entry_images",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "path_code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Path Code"
-            }
-          },
-          {
-            "name": "entry_slug",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Entry Slug"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ImageResponse"
-                  },
-                  "title": "Response List Entry Images"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/paths/{path_code}/subscriptions": {
-      "get": {
-        "tags": [
-          "subscriptions"
-        ],
-        "summary": "List Subscriptions",
-        "operationId": "list_subscriptions",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "path_code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Path Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/SubscriberResponse"
-                  },
-                  "title": "Response List Subscriptions"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "subscriptions"
-        ],
-        "summary": "Invite Subscriber",
-        "operationId": "invite_subscriber",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "path_code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Path Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SubscriptionInviteRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InviteResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/paths/{path_code}/subscriptions/{target_user_id}": {
-      "delete": {
-        "tags": [
-          "subscriptions"
-        ],
-        "summary": "Delete Subscription",
-        "operationId": "delete_subscription",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "path_code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Path Code"
-            }
-          },
-          {
-            "name": "target_user_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Target User Id"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/admin/login": {
-      "post": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin Login",
-        "operationId": "admin_login",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AdminLoginRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AdminLoginResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/admin/users/{user_id}/path-creation-approval": {
-      "put": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Set Path Creation Approval",
-        "operationId": "set_path_creation_approval",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "User Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PathCreationApprovalRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PathCreationApprovalResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/account/profile": {
-      "get": {
-        "tags": [
-          "account"
-        ],
-        "summary": "Get Profile",
-        "operationId": "get_profile",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserProfileResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ]
-      }
-    },
-    "/v1/account/display-name": {
-      "patch": {
-        "tags": [
-          "account"
-        ],
-        "summary": "Update Display Name",
-        "operationId": "update_display_name",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserDisplayNameUpdateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserProfileResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ]
-      }
-    },
-    "/v1/account/settings": {
-      "patch": {
-        "tags": [
-          "account"
-        ],
-        "summary": "Update Settings",
-        "operationId": "update_settings",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserSettingsUpdateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserProfileResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ]
-      }
-    },
-    "/v1/account/deletion-requests": {
-      "post": {
-        "tags": [
-          "account"
-        ],
-        "summary": "Create Deletion Request",
-        "operationId": "create_deletion_request",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeletionRequestResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ]
-      }
-    },
-    "/v1/account/deletion-requests/latest": {
-      "get": {
-        "tags": [
-          "account"
-        ],
-        "summary": "Latest Deletion Request",
-        "operationId": "get_latest_deletion_request",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeletionRequestResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ]
-      }
-    },
-    "/v1/images/{image_id}": {
-      "patch": {
-        "tags": [
-          "images"
-        ],
-        "summary": "Update Image Caption",
-        "operationId": "update_image_caption",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "image_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Image Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ImageCaptionUpdateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImageCaptionUpdateResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/images/{image_id}/download-url": {
-      "get": {
-        "tags": [
-          "images"
-        ],
-        "summary": "Get Image Download Url",
-        "operationId": "get_image_download_url",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "image_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Image Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImageDownloadResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/exports": {
-      "post": {
-        "tags": [
-          "exports"
-        ],
-        "summary": "Create Export",
-        "operationId": "create_export",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExportCreateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "202": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExportJobResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ]
-      }
-    },
-    "/v1/exports/{export_id}": {
-      "get": {
-        "tags": [
-          "exports"
-        ],
-        "summary": "Get Export",
-        "operationId": "get_export",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "export_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Export Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExportJobResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/exports/{export_id}/download/json": {
-      "get": {
-        "tags": [
-          "exports"
-        ],
-        "summary": "Download Json",
-        "operationId": "download_export_json",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "export_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Export Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DownloadURLResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/exports/{export_id}/download/images": {
-      "get": {
-        "tags": [
-          "exports"
-        ],
-        "summary": "Download Images",
-        "operationId": "download_export_images",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "export_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Export Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DownloadURLResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/auth/login": {
-      "get": {
-        "tags": [
-          "auth"
-        ],
-        "summary": "Oauth Login",
-        "description": "Return the Google OAuth authorization URL for the given callback URI.",
-        "operationId": "auth_login",
-        "parameters": [
-          {
-            "name": "callback_uri",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "URI that Google will redirect to after login",
-              "title": "Callback Uri"
-            },
-            "description": "URI that Google will redirect to after login"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OAuthLoginResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/auth/callback": {
-      "post": {
-        "tags": [
-          "auth"
-        ],
-        "summary": "Oauth Callback",
-        "description": "Exchange the OAuth code for a user session token.",
-        "operationId": "auth_callback",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OAuthCallbackRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OAuthCallbackResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "auth"
-        ],
-        "summary": "Oauth Callback Get",
-        "description": "Handle GET OAuth callback when the backend is the redirect target.\n\nThe callback_uri is extracted from the signed state token rather than\npassed as a query parameter, so it is guaranteed to match the value used\nduring the original login request.",
-        "operationId": "auth_callback_redirect",
-        "parameters": [
-          {
-            "name": "state",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "State"
-            }
-          },
-          {
-            "name": "code",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OAuthCallbackResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/invitations": {
-      "get": {
-        "tags": [
-          "invitations"
-        ],
-        "summary": "List Invitations",
-        "operationId": "list_invitations",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/InvitationResponse"
-                  },
-                  "type": "array",
-                  "title": "Response List Invitations"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ]
-      }
-    },
-    "/v1/invitations/{invitation_id}/accept": {
-      "post": {
-        "tags": [
-          "invitations"
-        ],
-        "summary": "Accept Invitation",
-        "operationId": "accept_invitation",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "invitation_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Invitation Id"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/invitations/{invitation_id}/ignore": {
-      "post": {
-        "tags": [
-          "invitations"
-        ],
-        "summary": "Ignore Invitation",
-        "operationId": "ignore_invitation",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "invitation_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Invitation Id"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/invitations/blocklist": {
-      "get": {
-        "tags": [
-          "invitations"
-        ],
-        "summary": "List Blocklist",
-        "operationId": "list_blocklist",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/BlocklistEntryResponse"
-                  },
-                  "type": "array",
-                  "title": "Response List Blocklist"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ]
-      },
-      "post": {
-        "tags": [
-          "invitations"
-        ],
-        "summary": "Block Inviter",
-        "operationId": "block_inviter",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BlocklistAddRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ]
-      }
-    },
-    "/v1/invitations/blocklist/{blocked_user_id}": {
-      "delete": {
-        "tags": [
-          "invitations"
-        ],
-        "summary": "Unblock User",
-        "operationId": "unblock_user",
-        "security": [
-          {
-            "APIKeyCookie": []
-          },
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "blocked_user_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Blocked User Id"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/": {
-      "get": {
-        "summary": "Root",
-        "operationId": "root",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        }
-      }
-    }
-  },
   "components": {
     "schemas": {
       "AdminLoginRequest": {
+        "example": {
+          "password": "s3cr3t",
+          "username": "admin"
+        },
         "properties": {
-          "username": {
-            "type": "string",
-            "title": "Username"
-          },
           "password": {
-            "type": "string",
-            "title": "Password"
+            "title": "Password",
+            "type": "string"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "username",
           "password"
         ],
         "title": "AdminLoginRequest",
-        "example": {
-          "password": "s3cr3t",
-          "username": "admin"
-        }
+        "type": "object"
       },
       "AdminLoginResponse": {
+        "example": {
+          "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.example"
+        },
         "properties": {
           "token": {
-            "type": "string",
-            "title": "Token"
+            "title": "Token",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "token"
         ],
         "title": "AdminLoginResponse",
-        "example": {
-          "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.example"
-        }
+        "type": "object"
       },
       "BlocklistAddRequest": {
+        "example": {
+          "user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        },
         "properties": {
           "user_id": {
-            "type": "string",
             "format": "uuid",
-            "title": "User Id"
+            "title": "User Id",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "user_id"
         ],
         "title": "BlocklistAddRequest",
-        "example": {
-          "user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-        }
+        "type": "object"
       },
       "BlocklistEntryResponse": {
+        "example": {
+          "blocked_user_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+          "created_at": "2024-03-15T09:00:00Z",
+          "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        },
         "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Id"
-          },
           "blocked_user_id": {
-            "type": "string",
             "format": "uuid",
-            "title": "Blocked User Id"
+            "title": "Blocked User Id",
+            "type": "string"
           },
           "created_at": {
-            "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "id",
           "blocked_user_id",
           "created_at"
         ],
         "title": "BlocklistEntryResponse",
-        "example": {
-          "blocked_user_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
-          "created_at": "2024-03-15T09:00:00Z",
-          "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-        }
+        "type": "object"
       },
       "Body_create_entry": {
         "properties": {
-          "entry_id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Entry Id",
-            "description": "Client-generated id; retries are idempotent."
-          },
-          "day": {
-            "type": "string",
-            "format": "date",
-            "title": "Day"
-          },
-          "content": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Content"
-          },
           "captions": {
             "items": {
               "type": "string"
             },
-            "type": "array",
-            "title": "Captions"
+            "title": "Captions",
+            "type": "array"
+          },
+          "content": {
+            "minLength": 1,
+            "title": "Content",
+            "type": "string"
+          },
+          "day": {
+            "format": "date",
+            "title": "Day",
+            "type": "string"
+          },
+          "entry_id": {
+            "description": "Client-generated id; retries are idempotent.",
+            "format": "uuid",
+            "title": "Entry Id",
+            "type": "string"
           },
           "images": {
+            "default": [],
             "items": {
-              "type": "string",
-              "contentMediaType": "application/octet-stream"
+              "contentMediaType": "application/octet-stream",
+              "type": "string"
             },
-            "type": "array",
             "title": "Images",
-            "default": []
+            "type": "array"
           }
         },
-        "type": "object",
         "required": [
           "entry_id",
           "day",
           "content"
         ],
-        "title": "Body_create_entry"
+        "title": "Body_create_entry",
+        "type": "object"
       },
       "Body_update_entry": {
         "properties": {
-          "expected_edit_id": {
-            "type": "integer",
-            "minimum": 1,
-            "title": "Expected Edit Id"
-          },
-          "content": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Content"
-          },
           "captions": {
             "items": {
               "type": "string"
             },
-            "type": "array",
-            "title": "Captions"
+            "title": "Captions",
+            "type": "array"
+          },
+          "content": {
+            "minLength": 1,
+            "title": "Content",
+            "type": "string"
+          },
+          "expected_edit_id": {
+            "minimum": 1.0,
+            "title": "Expected Edit Id",
+            "type": "integer"
+          },
+          "images": {
+            "default": [],
+            "items": {
+              "contentMediaType": "application/octet-stream",
+              "type": "string"
+            },
+            "title": "Images",
+            "type": "array"
           },
           "remove_image_ids": {
             "items": {
-              "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "type": "string"
             },
-            "type": "array",
-            "title": "Remove Image Ids"
-          },
-          "images": {
-            "items": {
-              "type": "string",
-              "contentMediaType": "application/octet-stream"
-            },
-            "type": "array",
-            "title": "Images",
-            "default": []
+            "title": "Remove Image Ids",
+            "type": "array"
           }
         },
-        "type": "object",
         "required": [
           "expected_edit_id",
           "content"
         ],
-        "title": "Body_update_entry"
+        "title": "Body_update_entry",
+        "type": "object"
       },
       "DeletionRequestResponse": {
+        "example": {
+          "attempt_count": 0,
+          "created_at": "2024-03-15T09:00:00Z",
+          "id": "f6a7b8c9-d0e1-2345-f012-456789012345",
+          "state": "requested",
+          "updated_at": "2024-03-15T09:00:00Z"
+        },
         "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Id"
+          "attempt_count": {
+            "title": "Attempt Count",
+            "type": "integer"
           },
-          "state": {
-            "type": "string",
-            "enum": [
-              "requested",
-              "running",
-              "complete",
-              "failed"
-            ],
-            "title": "State"
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
           },
           "error_message": {
             "anyOf": [
@@ -2001,22 +214,27 @@
             ],
             "title": "Failure Code"
           },
-          "attempt_count": {
-            "type": "integer",
-            "title": "Attempt Count"
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
           },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
+          "state": {
+            "enum": [
+              "requested",
+              "running",
+              "complete",
+              "failed"
+            ],
+            "title": "State",
+            "type": "string"
           },
           "updated_at": {
-            "type": "string",
             "format": "date-time",
-            "title": "Updated At"
+            "title": "Updated At",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "id",
           "state",
@@ -2025,76 +243,31 @@
           "updated_at"
         ],
         "title": "DeletionRequestResponse",
-        "example": {
-          "attempt_count": 0,
-          "created_at": "2024-03-15T09:00:00Z",
-          "id": "f6a7b8c9-d0e1-2345-f012-456789012345",
-          "state": "requested",
-          "updated_at": "2024-03-15T09:00:00Z"
-        }
+        "type": "object"
       },
       "DownloadURLResponse": {
+        "example": {
+          "expires_in_seconds": 300,
+          "url": "https://storage.example.com/exports/e5f6a7b8-c9d0-1234-ef01-345678901234/export.json?X-Amz-Expires=300"
+        },
         "properties": {
-          "url": {
-            "type": "string",
-            "title": "Url"
-          },
           "expires_in_seconds": {
-            "type": "integer",
-            "title": "Expires In Seconds"
+            "title": "Expires In Seconds",
+            "type": "integer"
+          },
+          "url": {
+            "title": "Url",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "url",
           "expires_in_seconds"
         ],
         "title": "DownloadURLResponse",
-        "example": {
-          "expires_in_seconds": 300,
-          "url": "https://storage.example.com/exports/e5f6a7b8-c9d0-1234-ef01-345678901234/export.json?X-Amz-Expires=300"
-        }
+        "type": "object"
       },
       "EntryContentResponse": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "path_id": {
-            "type": "string",
-            "title": "Path Id"
-          },
-          "day": {
-            "type": "string",
-            "format": "date",
-            "title": "Day"
-          },
-          "edit_id": {
-            "type": "integer",
-            "title": "Edit Id"
-          },
-          "content": {
-            "type": "string",
-            "title": "Content"
-          },
-          "images": {
-            "items": {
-              "$ref": "#/components/schemas/ImageResponse"
-            },
-            "type": "array",
-            "title": "Images"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "path_id",
-          "day",
-          "edit_id",
-          "content"
-        ],
-        "title": "EntryContentResponse",
         "example": {
           "content": "Feeling stronger today. Managed a 20-minute walk.",
           "day": "2024-03-15",
@@ -2112,29 +285,73 @@
             }
           ],
           "path_id": "AB3X7K"
-        }
-      },
-      "EntryResponse": {
+        },
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "path_id": {
-            "type": "string",
-            "title": "Path Id"
+          "content": {
+            "title": "Content",
+            "type": "string"
           },
           "day": {
-            "type": "string",
             "format": "date",
-            "title": "Day"
+            "title": "Day",
+            "type": "string"
           },
           "edit_id": {
-            "type": "integer",
-            "title": "Edit Id"
+            "title": "Edit Id",
+            "type": "integer"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "images": {
+            "items": {
+              "$ref": "#/components/schemas/ImageResponse"
+            },
+            "title": "Images",
+            "type": "array"
+          },
+          "path_id": {
+            "title": "Path Id",
+            "type": "string"
           }
         },
-        "type": "object",
+        "required": [
+          "id",
+          "path_id",
+          "day",
+          "edit_id",
+          "content"
+        ],
+        "title": "EntryContentResponse",
+        "type": "object"
+      },
+      "EntryResponse": {
+        "example": {
+          "day": "2024-03-15",
+          "edit_id": 1,
+          "id": "2026_02_20_0",
+          "path_id": "AB3X7K"
+        },
+        "properties": {
+          "day": {
+            "format": "date",
+            "title": "Day",
+            "type": "string"
+          },
+          "edit_id": {
+            "title": "Edit Id",
+            "type": "integer"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "path_id": {
+            "title": "Path Id",
+            "type": "string"
+          }
+        },
         "required": [
           "id",
           "path_id",
@@ -2142,98 +359,79 @@
           "edit_id"
         ],
         "title": "EntryResponse",
-        "example": {
-          "day": "2024-03-15",
-          "edit_id": 1,
-          "id": "2026_02_20_0",
-          "path_id": "AB3X7K"
-        }
+        "type": "object"
       },
       "ErrorDetail": {
+        "example": {
+          "code": "optimistic_lock_conflict",
+          "message": "Entry was modified by another request."
+        },
         "properties": {
           "code": {
-            "type": "string",
-            "title": "Code"
+            "title": "Code",
+            "type": "string"
           },
           "message": {
-            "type": "string",
-            "title": "Message"
+            "title": "Message",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "code",
           "message"
         ],
         "title": "ErrorDetail",
-        "example": {
-          "code": "optimistic_lock_conflict",
-          "message": "Entry was modified by another request."
-        }
+        "type": "object"
       },
       "ExportCreateRequest": {
+        "example": {
+          "path_ids": [
+            "AB3X7K"
+          ]
+        },
         "properties": {
           "path_ids": {
             "items": {
               "type": "string"
             },
-            "type": "array",
             "minItems": 1,
-            "title": "Path Ids"
+            "title": "Path Ids",
+            "type": "array"
           }
         },
-        "type": "object",
         "required": [
           "path_ids"
         ],
         "title": "ExportCreateRequest",
-        "example": {
-          "path_ids": [
-            "AB3X7K"
-          ]
-        }
+        "type": "object"
       },
       "ExportJobResponse": {
+        "example": {
+          "attempt_count": 1,
+          "created_at": "2024-03-15T09:00:00Z",
+          "expires_at": "2024-03-22T09:05:00Z",
+          "id": "e5f6a7b8-c9d0-1234-ef01-345678901234",
+          "requested_path_ids": [
+            "AB3X7K"
+          ],
+          "state": "ready",
+          "updated_at": "2024-03-15T09:05:00Z"
+        },
         "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Id"
-          },
-          "state": {
-            "type": "string",
-            "enum": [
-              "queued",
-              "running",
-              "ready",
-              "failed",
-              "expired",
-              "cleaned"
-            ],
-            "title": "State"
-          },
-          "requested_path_ids": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Requested Path Ids"
+          "attempt_count": {
+            "title": "Attempt Count",
+            "type": "integer"
           },
           "created_at": {
-            "type": "string",
             "format": "date-time",
-            "title": "Created At"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At"
+            "title": "Created At",
+            "type": "string"
           },
           "expires_at": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "format": "date-time",
+                "type": "string"
               },
               {
                 "type": "null"
@@ -2252,12 +450,36 @@
             ],
             "title": "Failure Code"
           },
-          "attempt_count": {
-            "type": "integer",
-            "title": "Attempt Count"
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "requested_path_ids": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Requested Path Ids",
+            "type": "array"
+          },
+          "state": {
+            "enum": [
+              "queued",
+              "running",
+              "ready",
+              "failed",
+              "expired",
+              "cleaned"
+            ],
+            "title": "State",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "id",
           "state",
@@ -2268,17 +490,7 @@
           "attempt_count"
         ],
         "title": "ExportJobResponse",
-        "example": {
-          "attempt_count": 1,
-          "created_at": "2024-03-15T09:00:00Z",
-          "expires_at": "2024-03-22T09:05:00Z",
-          "id": "e5f6a7b8-c9d0-1234-ef01-345678901234",
-          "requested_path_ids": [
-            "AB3X7K"
-          ],
-          "state": "ready",
-          "updated_at": "2024-03-15T09:05:00Z"
-        }
+        "type": "object"
       },
       "HTTPValidationError": {
         "properties": {
@@ -2286,51 +498,56 @@
             "items": {
               "$ref": "#/components/schemas/ValidationError"
             },
-            "type": "array",
-            "title": "Detail"
+            "title": "Detail",
+            "type": "array"
           }
         },
-        "type": "object",
-        "title": "HTTPValidationError"
+        "title": "HTTPValidationError",
+        "type": "object"
       },
       "HealthResponse": {
+        "example": {
+          "db": "ok",
+          "s3": "ok",
+          "service": "paths-backend",
+          "status": "ok"
+        },
         "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status",
-            "description": "Service health state.",
-            "examples": [
-              "ok"
-            ]
-          },
-          "service": {
-            "type": "string",
-            "title": "Service",
-            "description": "Service identifier.",
-            "examples": [
-              "paths-backend"
-            ]
-          },
           "db": {
-            "type": "string",
-            "title": "Db",
             "description": "Database connectivity status.",
             "examples": [
               "ok",
               "error"
-            ]
+            ],
+            "title": "Db",
+            "type": "string"
           },
           "s3": {
-            "type": "string",
-            "title": "S3",
             "description": "Object storage connectivity status.",
             "examples": [
               "ok",
               "error"
-            ]
+            ],
+            "title": "S3",
+            "type": "string"
+          },
+          "service": {
+            "description": "Service identifier.",
+            "examples": [
+              "paths-backend"
+            ],
+            "title": "Service",
+            "type": "string"
+          },
+          "status": {
+            "description": "Service health state.",
+            "examples": [
+              "ok"
+            ],
+            "title": "Status",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "status",
           "service",
@@ -2338,20 +555,19 @@
           "s3"
         ],
         "title": "HealthResponse",
-        "example": {
-          "db": "ok",
-          "s3": "ok",
-          "service": "paths-backend",
-          "status": "ok"
-        }
+        "type": "object"
       },
       "ImageCaptionUpdateRequest": {
+        "example": {
+          "caption": "Sunrise over the ridge",
+          "expected_edit_id": 2
+        },
         "properties": {
           "caption": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 2000
+                "maxLength": 2000,
+                "type": "string"
               },
               {
                 "type": "null"
@@ -2360,37 +576,18 @@
             "title": "Caption"
           },
           "expected_edit_id": {
-            "type": "integer",
-            "minimum": 1,
-            "title": "Expected Edit Id"
+            "minimum": 1.0,
+            "title": "Expected Edit Id",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
           "expected_edit_id"
         ],
         "title": "ImageCaptionUpdateRequest",
-        "example": {
-          "caption": "Sunrise over the ridge",
-          "expected_edit_id": 2
-        }
+        "type": "object"
       },
       "ImageCaptionUpdateResponse": {
-        "properties": {
-          "image": {
-            "$ref": "#/components/schemas/ImageResponse"
-          },
-          "edit_id": {
-            "type": "integer",
-            "title": "Edit Id"
-          }
-        },
-        "type": "object",
-        "required": [
-          "image",
-          "edit_id"
-        ],
-        "title": "ImageCaptionUpdateResponse",
         "example": {
           "edit_id": 3,
           "image": {
@@ -2402,13 +599,37 @@
             "id": "d4e5f6a7-b8c9-0123-def0-234567890123",
             "status": "ready"
           }
-        }
+        },
+        "properties": {
+          "edit_id": {
+            "title": "Edit Id",
+            "type": "integer"
+          },
+          "image": {
+            "$ref": "#/components/schemas/ImageResponse"
+          }
+        },
+        "required": [
+          "image",
+          "edit_id"
+        ],
+        "title": "ImageCaptionUpdateResponse",
+        "type": "object"
       },
       "ImageDownloadResponse": {
+        "example": {
+          "expires_in_seconds": 300,
+          "image_url": "https://storage.example.com/images/entry-id/photo.jpg?X-Amz-Expires=300",
+          "thumbnail_url": "https://storage.example.com/images/entry-id/thumb-photo.jpg?X-Amz-Expires=300"
+        },
         "properties": {
+          "expires_in_seconds": {
+            "title": "Expires In Seconds",
+            "type": "integer"
+          },
           "image_url": {
-            "type": "string",
-            "title": "Image Url"
+            "title": "Image Url",
+            "type": "string"
           },
           "thumbnail_url": {
             "anyOf": [
@@ -2420,40 +641,37 @@
               }
             ],
             "title": "Thumbnail Url"
-          },
-          "expires_in_seconds": {
-            "type": "integer",
-            "title": "Expires In Seconds"
           }
         },
-        "type": "object",
         "required": [
           "image_url",
           "thumbnail_url",
           "expires_in_seconds"
         ],
         "title": "ImageDownloadResponse",
-        "example": {
-          "expires_in_seconds": 300,
-          "image_url": "https://storage.example.com/images/entry-id/photo.jpg?X-Amz-Expires=300",
-          "thumbnail_url": "https://storage.example.com/images/entry-id/thumb-photo.jpg?X-Amz-Expires=300"
-        }
+        "type": "object"
       },
       "ImageResponse": {
+        "example": {
+          "byte_size": 204800,
+          "caption": "Sunrise over the ridge",
+          "content_type": "image/jpeg",
+          "entry_id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+          "filename": "morning-walk.jpg",
+          "id": "d4e5f6a7-b8c9-0123-def0-234567890123",
+          "status": "ready"
+        },
         "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Id"
-          },
-          "entry_id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Entry Id"
-          },
-          "filename": {
-            "type": "string",
-            "title": "Filename"
+          "byte_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Byte Size"
           },
           "caption": {
             "anyOf": [
@@ -2465,10 +683,6 @@
               }
             ],
             "title": "Caption"
-          },
-          "status": {
-            "type": "string",
-            "title": "Status"
           },
           "content_type": {
             "anyOf": [
@@ -2481,19 +695,25 @@
             ],
             "title": "Content Type"
           },
-          "byte_size": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Byte Size"
+          "entry_id": {
+            "format": "uuid",
+            "title": "Entry Id",
+            "type": "string"
+          },
+          "filename": {
+            "title": "Filename",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "id",
           "entry_id",
@@ -2504,40 +724,47 @@
           "byte_size"
         ],
         "title": "ImageResponse",
-        "example": {
-          "byte_size": 204800,
-          "caption": "Sunrise over the ridge",
-          "content_type": "image/jpeg",
-          "entry_id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
-          "filename": "morning-walk.jpg",
-          "id": "d4e5f6a7-b8c9-0123-def0-234567890123",
-          "status": "ready"
-        }
+        "type": "object"
       },
       "InvitationResponse": {
+        "example": {
+          "created_at": "2024-03-15T09:00:00Z",
+          "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          "invited_email": "subscriber@example.com",
+          "inviter_email": "owner@example.com",
+          "inviter_user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          "path_code": "AB3X7K",
+          "path_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+          "path_title": "My Travel Journal",
+          "status": "invited",
+          "updated_at": "2024-03-15T09:00:00Z"
+        },
         "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
           "id": {
-            "type": "string",
             "format": "uuid",
-            "title": "Id"
+            "title": "Id",
+            "type": "string"
           },
-          "path_id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Path Id"
+          "invited_email": {
+            "title": "Invited Email",
+            "type": "string"
           },
-          "path_code": {
-            "type": "string",
-            "title": "Path Code"
-          },
-          "path_title": {
-            "type": "string",
-            "title": "Path Title"
-          },
-          "inviter_user_id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Inviter User Id"
+          "invited_user_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Invited User Id"
           },
           "inviter_email": {
             "anyOf": [
@@ -2550,38 +777,34 @@
             ],
             "title": "Inviter Email"
           },
-          "invited_email": {
-            "type": "string",
-            "title": "Invited Email"
+          "inviter_user_id": {
+            "format": "uuid",
+            "title": "Inviter User Id",
+            "type": "string"
           },
-          "invited_user_id": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Invited User Id"
+          "path_code": {
+            "title": "Path Code",
+            "type": "string"
+          },
+          "path_id": {
+            "format": "uuid",
+            "title": "Path Id",
+            "type": "string"
+          },
+          "path_title": {
+            "title": "Path Title",
+            "type": "string"
           },
           "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
+            "title": "Status",
+            "type": "string"
           },
           "updated_at": {
-            "type": "string",
             "format": "date-time",
-            "title": "Updated At"
+            "title": "Updated At",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "id",
           "path_id",
@@ -2595,80 +818,66 @@
           "updated_at"
         ],
         "title": "InvitationResponse",
-        "example": {
-          "created_at": "2024-03-15T09:00:00Z",
-          "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-          "invited_email": "subscriber@example.com",
-          "inviter_email": "owner@example.com",
-          "inviter_user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-          "path_code": "AB3X7K",
-          "path_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
-          "path_title": "My Travel Journal",
-          "status": "invited",
-          "updated_at": "2024-03-15T09:00:00Z"
-        }
+        "type": "object"
       },
       "InviteResponse": {
+        "example": {
+          "invitation_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          "status": "invited"
+        },
         "properties": {
           "invitation_id": {
-            "type": "string",
             "format": "uuid",
-            "title": "Invitation Id"
+            "title": "Invitation Id",
+            "type": "string"
           },
           "status": {
-            "type": "string",
-            "title": "Status"
+            "title": "Status",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "invitation_id",
           "status"
         ],
         "title": "InviteResponse",
-        "example": {
-          "invitation_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-          "status": "invited"
-        }
+        "type": "object"
       },
       "OAuthCallbackRequest": {
+        "example": {
+          "callback_uri": "https://app.example.com/callback",
+          "code": "4/0AY0e-g7...",
+          "state": "a1b2c3d4e5f6"
+        },
         "properties": {
+          "callback_uri": {
+            "title": "Callback Uri",
+            "type": "string"
+          },
           "code": {
-            "type": "string",
-            "title": "Code"
+            "title": "Code",
+            "type": "string"
           },
           "state": {
-            "type": "string",
-            "title": "State"
-          },
-          "callback_uri": {
-            "type": "string",
-            "title": "Callback Uri"
+            "title": "State",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "code",
           "state",
           "callback_uri"
         ],
         "title": "OAuthCallbackRequest",
-        "example": {
-          "callback_uri": "https://app.example.com/callback",
-          "code": "4/0AY0e-g7...",
-          "state": "a1b2c3d4e5f6"
-        }
+        "type": "object"
       },
       "OAuthCallbackResponse": {
+        "example": {
+          "display_name": "Alex Smith",
+          "token": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          "user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        },
         "properties": {
-          "token": {
-            "type": "string",
-            "title": "Token"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
           "display_name": {
             "anyOf": [
               {
@@ -2679,58 +888,41 @@
               }
             ],
             "title": "Display Name"
+          },
+          "token": {
+            "title": "Token",
+            "type": "string"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "token",
           "user_id",
           "display_name"
         ],
         "title": "OAuthCallbackResponse",
-        "example": {
-          "display_name": "Alex Smith",
-          "token": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-          "user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-        }
+        "type": "object"
       },
       "OAuthLoginResponse": {
+        "example": {
+          "authorization_url": "https://accounts.google.com/o/oauth2/v2/auth?client_id=example.apps.googleusercontent.com&redirect_uri=https%3A%2F%2Fapp.example.com%2Fcallback&response_type=code&scope=openid+profile&state=..."
+        },
         "properties": {
           "authorization_url": {
-            "type": "string",
-            "title": "Authorization Url"
+            "title": "Authorization Url",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "authorization_url"
         ],
         "title": "OAuthLoginResponse",
-        "example": {
-          "authorization_url": "https://accounts.google.com/o/oauth2/v2/auth?client_id=example.apps.googleusercontent.com&redirect_uri=https%3A%2F%2Fapp.example.com%2Fcallback&response_type=code&scope=openid+profile&state=..."
-        }
+        "type": "object"
       },
       "OptimisticLockErrorResponse": {
-        "properties": {
-          "error": {
-            "$ref": "#/components/schemas/ErrorDetail"
-          },
-          "expected_edit_id": {
-            "type": "integer",
-            "title": "Expected Edit Id"
-          },
-          "current_edit_id": {
-            "type": "integer",
-            "title": "Current Edit Id"
-          }
-        },
-        "type": "object",
-        "required": [
-          "error",
-          "expected_edit_id",
-          "current_edit_id"
-        ],
-        "title": "OptimisticLockErrorResponse",
         "example": {
           "current_edit_id": 2,
           "error": {
@@ -2738,19 +930,29 @@
             "message": "Entry was modified by another request."
           },
           "expected_edit_id": 1
-        }
-      },
-      "OptimisticLockHTTPErrorResponse": {
+        },
         "properties": {
-          "detail": {
-            "$ref": "#/components/schemas/OptimisticLockErrorResponse"
+          "current_edit_id": {
+            "title": "Current Edit Id",
+            "type": "integer"
+          },
+          "error": {
+            "$ref": "#/components/schemas/ErrorDetail"
+          },
+          "expected_edit_id": {
+            "title": "Expected Edit Id",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
-          "detail"
+          "error",
+          "expected_edit_id",
+          "current_edit_id"
         ],
-        "title": "OptimisticLockHTTPErrorResponse",
+        "title": "OptimisticLockErrorResponse",
+        "type": "object"
+      },
+      "OptimisticLockHTTPErrorResponse": {
         "example": {
           "detail": {
             "current_edit_id": 2,
@@ -2760,21 +962,35 @@
             },
             "expected_edit_id": 1
           }
-        }
+        },
+        "properties": {
+          "detail": {
+            "$ref": "#/components/schemas/OptimisticLockErrorResponse"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "title": "OptimisticLockHTTPErrorResponse",
+        "type": "object"
       },
       "PathCreateRequest": {
+        "example": {
+          "color": "#4F46E5",
+          "description": "Tracking sleep, movement, and gratitude.",
+          "title": "Recovery Journal"
+        },
         "properties": {
-          "title": {
-            "type": "string",
-            "maxLength": 120,
-            "minLength": 1,
-            "title": "Title"
+          "color": {
+            "pattern": "^#[0-9A-Fa-f]{6}$",
+            "title": "Color",
+            "type": "string"
           },
           "description": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 1024
+                "maxLength": 1024,
+                "type": "string"
               },
               {
                 "type": "null"
@@ -2782,82 +998,80 @@
             ],
             "title": "Description"
           },
-          "color": {
-            "type": "string",
-            "pattern": "^#[0-9A-Fa-f]{6}$",
-            "title": "Color"
+          "title": {
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "title",
           "color"
         ],
         "title": "PathCreateRequest",
-        "example": {
-          "color": "#4F46E5",
-          "description": "Tracking sleep, movement, and gratitude.",
-          "title": "Recovery Journal"
-        }
+        "type": "object"
       },
       "PathCreationApprovalRequest": {
+        "example": {
+          "allowed": true
+        },
         "properties": {
           "allowed": {
-            "type": "boolean",
-            "title": "Allowed"
+            "title": "Allowed",
+            "type": "boolean"
           }
         },
-        "type": "object",
         "required": [
           "allowed"
         ],
         "title": "PathCreationApprovalRequest",
-        "example": {
-          "allowed": true
-        }
+        "type": "object"
       },
       "PathCreationApprovalResponse": {
+        "example": {
+          "allowed": true,
+          "user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        },
         "properties": {
-          "user_id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "User Id"
-          },
           "allowed": {
-            "type": "boolean",
-            "title": "Allowed"
+            "title": "Allowed",
+            "type": "boolean"
+          },
+          "user_id": {
+            "format": "uuid",
+            "title": "User Id",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "user_id",
           "allowed"
         ],
         "title": "PathCreationApprovalResponse",
-        "example": {
-          "allowed": true,
-          "user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-        }
+        "type": "object"
       },
       "PathResponse": {
+        "example": {
+          "color": "#4F46E5",
+          "created_at": "2024-03-15T09:00:00Z",
+          "description": "Tracking sleep, movement, and gratitude.",
+          "is_public": false,
+          "owner_user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          "path_id": "AB3X7K",
+          "title": "Recovery Journal",
+          "updated_at": "2024-03-15T09:00:00Z",
+          "uuid": "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+        },
         "properties": {
-          "path_id": {
-            "type": "string",
-            "title": "Path Id"
+          "color": {
+            "title": "Color",
+            "type": "string"
           },
-          "uuid": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Uuid"
-          },
-          "owner_user_id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Owner User Id"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
           },
           "description": {
             "anyOf": [
@@ -2870,26 +1084,34 @@
             ],
             "title": "Description"
           },
-          "color": {
-            "type": "string",
-            "title": "Color"
-          },
           "is_public": {
-            "type": "boolean",
-            "title": "Is Public"
+            "title": "Is Public",
+            "type": "boolean"
           },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
+          "owner_user_id": {
+            "format": "uuid",
+            "title": "Owner User Id",
+            "type": "string"
+          },
+          "path_id": {
+            "title": "Path Id",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
           },
           "updated_at": {
-            "type": "string",
             "format": "date-time",
-            "title": "Updated At"
+            "title": "Updated At",
+            "type": "string"
+          },
+          "uuid": {
+            "format": "uuid",
+            "title": "Uuid",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "path_id",
           "uuid",
@@ -2902,38 +1124,32 @@
           "updated_at"
         ],
         "title": "PathResponse",
-        "example": {
-          "color": "#4F46E5",
-          "created_at": "2024-03-15T09:00:00Z",
-          "description": "Tracking sleep, movement, and gratitude.",
-          "is_public": false,
-          "owner_user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-          "path_id": "AB3X7K",
-          "title": "Recovery Journal",
-          "updated_at": "2024-03-15T09:00:00Z",
-          "uuid": "b2c3d4e5-f6a7-8901-bcde-f12345678901"
-        }
+        "type": "object"
       },
       "PathUpdateRequest": {
+        "example": {
+          "color": "#10B981",
+          "description": "Revised description.",
+          "title": "Updated Journal"
+        },
         "properties": {
-          "title": {
+          "color": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 120,
-                "minLength": 1
+                "pattern": "^#[0-9A-Fa-f]{6}$",
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Title"
+            "title": "Color"
           },
           "description": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 1024
+                "maxLength": 1024,
+                "type": "string"
               },
               {
                 "type": "null"
@@ -2941,49 +1157,56 @@
             ],
             "title": "Description"
           },
-          "color": {
+          "title": {
             "anyOf": [
               {
-                "type": "string",
-                "pattern": "^#[0-9A-Fa-f]{6}$"
+                "maxLength": 120,
+                "minLength": 1,
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Color"
+            "title": "Title"
           }
         },
-        "type": "object",
         "title": "PathUpdateRequest",
-        "example": {
-          "color": "#10B981",
-          "description": "Revised description.",
-          "title": "Updated Journal"
-        }
+        "type": "object"
       },
       "PathVisibilityUpdateRequest": {
+        "example": {
+          "is_public": true
+        },
         "properties": {
           "is_public": {
-            "type": "boolean",
-            "title": "Is Public"
+            "title": "Is Public",
+            "type": "boolean"
           }
         },
-        "type": "object",
         "required": [
           "is_public"
         ],
         "title": "PathVisibilityUpdateRequest",
-        "example": {
-          "is_public": true
-        }
+        "type": "object"
       },
       "SubscriberResponse": {
+        "example": {
+          "display_name": "Alex Smith",
+          "email": "subscriber@example.com",
+          "user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        },
         "properties": {
-          "user_id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "User Id"
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
           },
           "email": {
             "anyOf": [
@@ -2996,56 +1219,48 @@
             ],
             "title": "Email"
           },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
+          "user_id": {
+            "format": "uuid",
+            "title": "User Id",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "user_id",
           "email",
           "display_name"
         ],
         "title": "SubscriberResponse",
-        "example": {
-          "display_name": "Alex Smith",
-          "email": "subscriber@example.com",
-          "user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-        }
+        "type": "object"
       },
       "SubscriptionInviteRequest": {
+        "example": {
+          "email": "newsubscriber@example.com"
+        },
         "properties": {
           "email": {
-            "type": "string",
             "maxLength": 256,
             "pattern": "^[^@\\s]+@[^@\\s]+$",
-            "title": "Email"
+            "title": "Email",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "email"
         ],
         "title": "SubscriptionInviteRequest",
-        "example": {
-          "email": "newsubscriber@example.com"
-        }
+        "type": "object"
       },
       "UserDisplayNameUpdateRequest": {
+        "example": {
+          "display_name": "Alex Smith"
+        },
         "properties": {
           "display_name": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 100
+                "maxLength": 100,
+                "type": "string"
               },
               {
                 "type": "null"
@@ -3054,19 +1269,15 @@
             "title": "Display Name"
           }
         },
-        "type": "object",
         "title": "UserDisplayNameUpdateRequest",
-        "example": {
-          "display_name": "Alex Smith"
-        }
+        "type": "object"
       },
       "UserProfileResponse": {
+        "example": {
+          "display_name": "Alex Smith",
+          "user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        },
         "properties": {
-          "user_id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "User Id"
-          },
           "display_name": {
             "anyOf": [
               {
@@ -3088,26 +1299,30 @@
               }
             ],
             "title": "Settings Json"
+          },
+          "user_id": {
+            "format": "uuid",
+            "title": "User Id",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "user_id",
           "display_name"
         ],
         "title": "UserProfileResponse",
-        "example": {
-          "display_name": "Alex Smith",
-          "user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-        }
+        "type": "object"
       },
       "UserSettingsUpdateRequest": {
+        "example": {
+          "settings_json": "{\"theme\":\"dark\"}"
+        },
         "properties": {
           "settings_json": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 1024
+                "maxLength": 1024,
+                "type": "string"
               },
               {
                 "type": "null"
@@ -3116,14 +1331,18 @@
             "title": "Settings Json"
           }
         },
-        "type": "object",
         "title": "UserSettingsUpdateRequest",
-        "example": {
-          "settings_json": "{\"theme\":\"dark\"}"
-        }
+        "type": "object"
       },
       "ValidationError": {
         "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
           "loc": {
             "items": {
               "anyOf": [
@@ -3135,45 +1354,1887 @@
                 }
               ]
             },
-            "type": "array",
-            "title": "Location"
+            "title": "Location",
+            "type": "array"
           },
           "msg": {
-            "type": "string",
-            "title": "Message"
+            "title": "Message",
+            "type": "string"
           },
           "type": {
-            "type": "string",
-            "title": "Error Type"
-          },
-          "input": {
-            "title": "Input"
-          },
-          "ctx": {
-            "type": "object",
-            "title": "Context"
+            "title": "Error Type",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "loc",
           "msg",
           "type"
         ],
-        "title": "ValidationError"
+        "title": "ValidationError",
+        "type": "object"
       }
     },
     "securitySchemes": {
       "APIKeyCookie": {
-        "type": "apiKey",
         "description": "Session token cookie obtained via Oauth callback",
         "in": "cookie",
-        "name": "session_token"
+        "name": "session_token",
+        "type": "apiKey"
       },
       "HTTPBearer": {
-        "type": "http",
         "description": "****** from the OAuth callback response body",
-        "scheme": "bearer"
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "summary": "Path-centric backend API for Shared Journal PWA",
+    "title": "paths backend API",
+    "version": "0.4.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "root",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Root"
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "health",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Health",
+        "tags": [
+          "health"
+        ]
+      }
+    },
+    "/v1/account/deletion-requests": {
+      "post": {
+        "operationId": "create_deletion_request",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletionRequestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Deletion Request",
+        "tags": [
+          "account"
+        ]
+      }
+    },
+    "/v1/account/deletion-requests/latest": {
+      "get": {
+        "operationId": "get_latest_deletion_request",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletionRequestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Latest Deletion Request",
+        "tags": [
+          "account"
+        ]
+      }
+    },
+    "/v1/account/display-name": {
+      "patch": {
+        "operationId": "update_display_name",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserDisplayNameUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserProfileResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Display Name",
+        "tags": [
+          "account"
+        ]
+      }
+    },
+    "/v1/account/profile": {
+      "get": {
+        "operationId": "get_profile",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserProfileResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Profile",
+        "tags": [
+          "account"
+        ]
+      }
+    },
+    "/v1/account/settings": {
+      "patch": {
+        "operationId": "update_settings",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserSettingsUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserProfileResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Settings",
+        "tags": [
+          "account"
+        ]
+      }
+    },
+    "/v1/admin/login": {
+      "post": {
+        "operationId": "admin_login",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminLoginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminLoginResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Login",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/v1/admin/users/{user_id}/path-creation-approval": {
+      "put": {
+        "operationId": "set_path_creation_approval",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PathCreationApprovalRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PathCreationApprovalResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Set Path Creation Approval",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/v1/auth/callback": {
+      "get": {
+        "description": "Handle GET OAuth callback when the backend is the redirect target.\n\nThe callback_uri is extracted from the signed state token rather than\npassed as a query parameter, so it is guaranteed to match the value used\nduring the original login request.",
+        "operationId": "auth_callback_redirect",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "state",
+            "required": true,
+            "schema": {
+              "title": "State",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthCallbackResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Oauth Callback Get",
+        "tags": [
+          "auth"
+        ]
+      },
+      "post": {
+        "description": "Exchange the OAuth code for a user session token.",
+        "operationId": "auth_callback",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OAuthCallbackRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthCallbackResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Oauth Callback",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/v1/auth/login": {
+      "get": {
+        "description": "Return the Google OAuth authorization URL for the given callback URI.",
+        "operationId": "auth_login",
+        "parameters": [
+          {
+            "description": "URI that Google will redirect to after login",
+            "in": "query",
+            "name": "callback_uri",
+            "required": true,
+            "schema": {
+              "description": "URI that Google will redirect to after login",
+              "title": "Callback Uri",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthLoginResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Oauth Login",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/v1/entries/versions": {
+      "get": {
+        "description": "Cheap {path_id: {entry_id: edit_id}} map for polling many paths at once.\n\nA dedicated round trip so pollers can diff versions and only fetch full\nentry content for what actually changed, instead of re-fetching every\npath's full entry list on every tick.\n\nUnknown or inaccessible path_ids are silently omitted rather than\nfailing the whole request \u2014 same as a caller not being subscribed to a\npath simply not seeing it in list_paths.",
+        "operationId": "get_entry_versions",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "path_ids",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "title": "Path Ids",
+              "type": "array"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "title": "Response Get Entry Versions",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Entry Versions",
+        "tags": [
+          "entries"
+        ]
+      }
+    },
+    "/v1/exports": {
+      "post": {
+        "operationId": "create_export",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExportJobResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Export",
+        "tags": [
+          "exports"
+        ]
+      }
+    },
+    "/v1/exports/{export_id}": {
+      "get": {
+        "operationId": "get_export",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "export_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Export Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExportJobResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Export",
+        "tags": [
+          "exports"
+        ]
+      }
+    },
+    "/v1/exports/{export_id}/download/images": {
+      "get": {
+        "operationId": "download_export_images",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "export_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Export Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadURLResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Download Images",
+        "tags": [
+          "exports"
+        ]
+      }
+    },
+    "/v1/exports/{export_id}/download/json": {
+      "get": {
+        "operationId": "download_export_json",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "export_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Export Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadURLResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Download Json",
+        "tags": [
+          "exports"
+        ]
+      }
+    },
+    "/v1/images/{image_id}": {
+      "patch": {
+        "operationId": "update_image_caption",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "image_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Image Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImageCaptionUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageCaptionUpdateResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Image Caption",
+        "tags": [
+          "images"
+        ]
+      }
+    },
+    "/v1/images/{image_id}/download-url": {
+      "get": {
+        "operationId": "get_image_download_url",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "image_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Image Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageDownloadResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Image Download Url",
+        "tags": [
+          "images"
+        ]
+      }
+    },
+    "/v1/invitations": {
+      "get": {
+        "operationId": "list_invitations",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/InvitationResponse"
+                  },
+                  "title": "Response List Invitations",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Invitations",
+        "tags": [
+          "invitations"
+        ]
+      }
+    },
+    "/v1/invitations/blocklist": {
+      "get": {
+        "operationId": "list_blocklist",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/BlocklistEntryResponse"
+                  },
+                  "title": "Response List Blocklist",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Blocklist",
+        "tags": [
+          "invitations"
+        ]
+      },
+      "post": {
+        "operationId": "block_inviter",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BlocklistAddRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Block Inviter",
+        "tags": [
+          "invitations"
+        ]
+      }
+    },
+    "/v1/invitations/blocklist/{blocked_user_id}": {
+      "delete": {
+        "operationId": "unblock_user",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "blocked_user_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Blocked User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Unblock User",
+        "tags": [
+          "invitations"
+        ]
+      }
+    },
+    "/v1/invitations/{invitation_id}/accept": {
+      "post": {
+        "operationId": "accept_invitation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "invitation_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Invitation Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Accept Invitation",
+        "tags": [
+          "invitations"
+        ]
+      }
+    },
+    "/v1/invitations/{invitation_id}/ignore": {
+      "post": {
+        "operationId": "ignore_invitation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "invitation_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Invitation Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Ignore Invitation",
+        "tags": [
+          "invitations"
+        ]
+      }
+    },
+    "/v1/paths": {
+      "get": {
+        "operationId": "list_paths",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/PathResponse"
+                  },
+                  "title": "Response List Paths",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Paths",
+        "tags": [
+          "paths"
+        ]
+      },
+      "post": {
+        "operationId": "create_path",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PathCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PathResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Path",
+        "tags": [
+          "paths"
+        ]
+      }
+    },
+    "/v1/paths/{path_code}": {
+      "delete": {
+        "operationId": "delete_path",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "path_code",
+            "required": true,
+            "schema": {
+              "title": "Path Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete Path",
+        "tags": [
+          "paths"
+        ]
+      },
+      "patch": {
+        "operationId": "update_path",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "path_code",
+            "required": true,
+            "schema": {
+              "title": "Path Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PathUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PathResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Path",
+        "tags": [
+          "paths"
+        ]
+      }
+    },
+    "/v1/paths/{path_code}/entries": {
+      "get": {
+        "operationId": "list_entries",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "path_code",
+            "required": true,
+            "schema": {
+              "title": "Path Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/EntryResponse"
+                  },
+                  "title": "Response List Entries",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Entries",
+        "tags": [
+          "entries"
+        ]
+      },
+      "post": {
+        "operationId": "create_entry",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "path_code",
+            "required": true,
+            "schema": {
+              "title": "Path Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_create_entry"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Entry",
+        "tags": [
+          "entries"
+        ]
+      }
+    },
+    "/v1/paths/{path_code}/entries/{entry_slug}": {
+      "delete": {
+        "operationId": "delete_entry",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "path_code",
+            "required": true,
+            "schema": {
+              "title": "Path Code",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "entry_slug",
+            "required": true,
+            "schema": {
+              "title": "Entry Slug",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete Entry",
+        "tags": [
+          "entries"
+        ]
+      },
+      "get": {
+        "operationId": "get_entry",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "path_code",
+            "required": true,
+            "schema": {
+              "title": "Path Code",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "entry_slug",
+            "required": true,
+            "schema": {
+              "title": "Entry Slug",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryContentResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Entry",
+        "tags": [
+          "entries"
+        ]
+      },
+      "put": {
+        "operationId": "update_entry",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "path_code",
+            "required": true,
+            "schema": {
+              "title": "Path Code",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "entry_slug",
+            "required": true,
+            "schema": {
+              "title": "Entry Slug",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_update_entry"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OptimisticLockHTTPErrorResponse"
+                }
+              }
+            },
+            "description": "Optimistic lock mismatch for expected_edit_id."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Entry",
+        "tags": [
+          "entries"
+        ]
+      }
+    },
+    "/v1/paths/{path_code}/entries/{entry_slug}/images": {
+      "get": {
+        "operationId": "list_entry_images",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "path_code",
+            "required": true,
+            "schema": {
+              "title": "Path Code",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "entry_slug",
+            "required": true,
+            "schema": {
+              "title": "Entry Slug",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ImageResponse"
+                  },
+                  "title": "Response List Entry Images",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Entry Images",
+        "tags": [
+          "entries"
+        ]
+      }
+    },
+    "/v1/paths/{path_code}/subscriptions": {
+      "get": {
+        "operationId": "list_subscriptions",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "path_code",
+            "required": true,
+            "schema": {
+              "title": "Path Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/SubscriberResponse"
+                  },
+                  "title": "Response List Subscriptions",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Subscriptions",
+        "tags": [
+          "subscriptions"
+        ]
+      },
+      "post": {
+        "operationId": "invite_subscriber",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "path_code",
+            "required": true,
+            "schema": {
+              "title": "Path Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubscriptionInviteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InviteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Invite Subscriber",
+        "tags": [
+          "subscriptions"
+        ]
+      }
+    },
+    "/v1/paths/{path_code}/subscriptions/{target_user_id}": {
+      "delete": {
+        "operationId": "delete_subscription",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "path_code",
+            "required": true,
+            "schema": {
+              "title": "Path Code",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "target_user_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Target User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete Subscription",
+        "tags": [
+          "subscriptions"
+        ]
+      }
+    },
+    "/v1/paths/{path_code}/visibility": {
+      "patch": {
+        "operationId": "update_path_visibility",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "path_code",
+            "required": true,
+            "schema": {
+              "title": "Path Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PathVisibilityUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PathResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Path Visibility",
+        "tags": [
+          "paths"
+        ]
       }
     }
   }

--- a/src/__tests__/customFetch.test.ts
+++ b/src/__tests__/customFetch.test.ts
@@ -4,6 +4,15 @@ const mockFetch = vi.fn();
 
 vi.stubGlobal('fetch', mockFetch);
 
+const mockGetEtag = vi.fn();
+const mockSetEtag = vi.fn();
+const mockClearEtags = vi.fn();
+vi.mock('../lib/etagStore', () => ({
+  getEtag: (...args: unknown[]) => mockGetEtag(...args),
+  setEtag: (...args: unknown[]) => mockSetEtag(...args),
+  clearEtags: (...args: unknown[]) => mockClearEtags(...args),
+}));
+
 // Stub localStorage for bearer-token tests
 const localStorageStore: Record<string, string> = {};
 vi.stubGlobal('localStorage', {
@@ -31,6 +40,12 @@ beforeEach(() => {
     headers: new Headers(),
     json: vi.fn().mockResolvedValue({}),
   });
+  mockGetEtag.mockReset();
+  mockGetEtag.mockResolvedValue(undefined);
+  mockSetEtag.mockReset();
+  mockSetEtag.mockResolvedValue(undefined);
+  mockClearEtags.mockReset();
+  mockClearEtags.mockResolvedValue(undefined);
   // Clear stored token between tests
   delete localStorageStore['session_token'];
 });
@@ -265,5 +280,75 @@ describe('customFetch', () => {
     };
     expect(result.data).toBeUndefined();
     expect(result.status).toBe(204);
+  });
+
+  it('sends If-None-Match with the cached etag on a GET request', async () => {
+    mockGetEtag.mockResolvedValue({
+      etag: 'W/"abc123"',
+      body: { cached: true },
+    });
+
+    const { customFetch } = await import('../lib/customFetch');
+    await customFetch('/v1/paths');
+
+    const [, fetchOptions] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = fetchOptions.headers as Record<string, string>;
+    expect(headers['If-None-Match']).toBe('W/"abc123"');
+  });
+
+  it('does not look up or send an etag for a non-GET request', async () => {
+    const { customFetch } = await import('../lib/customFetch');
+    await customFetch('/v1/paths', { method: 'POST', body: '{}' });
+
+    expect(mockGetEtag).not.toHaveBeenCalled();
+    const [, fetchOptions] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = fetchOptions.headers as Record<string, string>;
+    expect(headers['If-None-Match']).toBeUndefined();
+  });
+
+  it('resolves a 304 using the cached body instead of parsing the empty response', async () => {
+    mockGetEtag.mockResolvedValue({
+      etag: 'W/"abc123"',
+      body: { title: 'cached' },
+    });
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 304,
+      headers: new Headers(),
+      json: vi.fn().mockRejectedValue(new Error('should not be called on 304')),
+    });
+
+    const { customFetch } = await import('../lib/customFetch');
+    const result = (await customFetch('/v1/paths')) as {
+      data: unknown;
+      status: number;
+    };
+    expect(result.data).toEqual({ title: 'cached' });
+    expect(result.status).toBe(200);
+  });
+
+  it('stores the new etag and body when a GET responds 200 with an ETag header', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ ETag: 'W/"new-etag"' }),
+      json: vi.fn().mockResolvedValue({ title: 'fresh' }),
+    });
+
+    const { customFetch } = await import('../lib/customFetch');
+    await customFetch('/v1/paths');
+
+    expect(mockSetEtag).toHaveBeenCalledWith(
+      expect.stringContaining('/v1/paths'),
+      'W/"new-etag"',
+      { title: 'fresh' },
+    );
+  });
+
+  it('does not store an etag when the response carries none', async () => {
+    const { customFetch } = await import('../lib/customFetch');
+    await customFetch('/v1/paths');
+
+    expect(mockSetEtag).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/etagStore.test.ts
+++ b/src/__tests__/etagStore.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const store = new Map<string, { url: string; etag: string; body: unknown }>();
+
+vi.mock('../lib/db', () => ({
+  db: {
+    etagCache: {
+      get: vi.fn((url: string) => Promise.resolve(store.get(url))),
+      put: vi.fn((entry: { url: string; etag: string; body: unknown }) => {
+        store.set(entry.url, entry);
+        return Promise.resolve();
+      }),
+      clear: vi.fn(() => {
+        store.clear();
+        return Promise.resolve();
+      }),
+    },
+  },
+}));
+
+import { getEtag, setEtag, clearEtags } from '../lib/etagStore';
+
+beforeEach(() => {
+  store.clear();
+});
+
+describe('etagStore', () => {
+  it('returns undefined for a URL with no cached entry', async () => {
+    await expect(getEtag('/v1/paths')).resolves.toBeUndefined();
+  });
+
+  it('round-trips a set etag and body through get', async () => {
+    await setEtag('/v1/paths', 'W/"abc"', { title: 'hello' });
+
+    await expect(getEtag('/v1/paths')).resolves.toEqual({
+      etag: 'W/"abc"',
+      body: { title: 'hello' },
+    });
+  });
+
+  it('clearEtags removes all cached entries', async () => {
+    await setEtag('/v1/paths', 'W/"abc"', { title: 'hello' });
+    await clearEtags();
+
+    await expect(getEtag('/v1/paths')).resolves.toBeUndefined();
+  });
+});
+
+describe('etagStore – graceful Dexie failures', () => {
+  it('getEtag resolves undefined when Dexie rejects', async () => {
+    vi.resetModules();
+    vi.doMock('../lib/db', () => ({
+      db: {
+        etagCache: {
+          get: vi.fn().mockRejectedValue(new Error('IndexedDB unavailable')),
+          put: vi.fn().mockRejectedValue(new Error('IndexedDB unavailable')),
+          clear: vi.fn().mockRejectedValue(new Error('IndexedDB unavailable')),
+        },
+      },
+    }));
+    const failing = await import('../lib/etagStore');
+
+    await expect(failing.getEtag('/v1/paths')).resolves.toBeUndefined();
+    await expect(
+      failing.setEtag('/v1/paths', 'W/"abc"', {}),
+    ).resolves.toBeUndefined();
+    await expect(failing.clearEtags()).resolves.toBeUndefined();
+  });
+});

--- a/src/__tests__/useMultiPathEntries.versions.test.ts
+++ b/src/__tests__/useMultiPathEntries.versions.test.ts
@@ -1,0 +1,131 @@
+/**
+ * useMultiPathEntries used to poll every subscribed path's full entry list on its own
+ * 25s interval. It now polls one shared GET /v1/entries/versions map instead, and only
+ * invalidates (and thus refetches) a path's entry list when that path's version map
+ * actually changed. These tests pin down the diff behavior directly, without waiting on
+ * the real interval — driven via an explicit refetch of the versions query, the same way
+ * useMultiPathEntries.window.test.ts drives the list query directly.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref, type Ref } from 'vue';
+import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query';
+import { mount, flushPromises } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+
+vi.mock('../lib/customFetch', () => ({
+  customFetch: vi.fn(),
+}));
+
+vi.mock('../lib/db', () => ({
+  db: {
+    entryContent: { get: vi.fn().mockResolvedValue(undefined), put: vi.fn() },
+    entryImages: {
+      where: vi.fn().mockReturnValue({
+        equals: vi.fn().mockReturnValue({
+          toArray: vi.fn().mockResolvedValue([]),
+          delete: vi.fn(),
+        }),
+      }),
+      bulkPut: vi.fn(),
+    },
+    pathPreferences: {},
+    queryCache: {},
+  },
+  isPathHidden: vi.fn().mockResolvedValue(false),
+  setPathHidden: vi.fn().mockResolvedValue(undefined),
+  getPathOrder: vi.fn().mockReturnValue([]),
+  setPathOrder: vi.fn(),
+}));
+
+import { customFetch } from '../lib/customFetch';
+import { useMultiPathEntries } from '../composables/useMultiPathEntries';
+
+function mount1(pathIds: Ref<string[]>) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  let result: ReturnType<typeof useMultiPathEntries> | undefined;
+  const TestComponent = defineComponent({
+    setup() {
+      result = useMultiPathEntries(pathIds);
+      return {};
+    },
+    template: '<div></div>',
+  });
+  mount(TestComponent, {
+    global: { plugins: [[VueQueryPlugin, { queryClient }]] },
+  });
+  return { result: () => result!, queryClient };
+}
+
+describe('useMultiPathEntries – versions-driven polling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('refetches only a path whose versions map changed', async () => {
+    let editId = 1;
+    const listCallCounts = { p1: 0, p2: 0 };
+
+    vi.mocked(customFetch).mockImplementation((url: string) => {
+      if (url.startsWith('/v1/entries/versions')) {
+        return Promise.resolve({
+          data: {
+            p1: { e1: editId },
+            p2: { e2: 1 },
+          },
+          status: 200,
+          headers: new Headers(),
+        });
+      }
+      if (url === '/v1/paths/p1/entries') {
+        listCallCounts.p1++;
+        return Promise.resolve({
+          data: [
+            { id: 'e1', path_id: 'p1', day: '2024-01-01', edit_id: editId },
+          ],
+          status: 200,
+          headers: new Headers(),
+        });
+      }
+      if (url === '/v1/paths/p2/entries') {
+        listCallCounts.p2++;
+        return Promise.resolve({
+          data: [{ id: 'e2', path_id: 'p2', day: '2024-01-01', edit_id: 1 }],
+          status: 200,
+          headers: new Headers(),
+        });
+      }
+      return Promise.resolve({ data: [], status: 200, headers: new Headers() });
+    });
+
+    const pathIds = ref(['p1', 'p2']);
+    const { queryClient } = mount1(pathIds);
+    await flushPromises();
+    await flushPromises();
+
+    expect(listCallCounts.p1).toBe(1);
+    expect(listCallCounts.p2).toBe(1);
+
+    // Nothing changed — a repeat versions poll must not invalidate either list.
+    await queryClient.refetchQueries({
+      queryKey: ['v1', 'entries', 'versions'],
+    });
+    await flushPromises();
+    await flushPromises();
+
+    expect(listCallCounts.p1).toBe(1);
+    expect(listCallCounts.p2).toBe(1);
+
+    // p1's entry edit_id bumps — only p1's list should be invalidated and refetched.
+    editId = 2;
+    await queryClient.refetchQueries({
+      queryKey: ['v1', 'entries', 'versions'],
+    });
+    await flushPromises();
+    await flushPromises();
+
+    expect(listCallCounts.p1).toBe(2);
+    expect(listCallCounts.p2).toBe(1);
+  });
+});

--- a/src/composables/useMultiPathEntries.ts
+++ b/src/composables/useMultiPathEntries.ts
@@ -1,8 +1,44 @@
 import { computed, ref, watch, type Ref } from 'vue';
-import { useQueries } from '@tanstack/vue-query';
-import { listEntries, getEntry } from '../generated/apiClient';
+import { useQueries, useQueryClient } from '@tanstack/vue-query';
+import {
+  listEntries,
+  getEntry,
+  useGetEntryVersions,
+} from '../generated/apiClient';
 import type { EntryContentResponse, EntryResponse } from '../generated/types';
 import type { ImageResponse } from '../generated/types';
+
+type VersionsMap = Record<string, Record<string, number>>;
+
+/** Which path_ids have at least one entry whose edit_id differs between two version
+ *  snapshots (including an entry appearing/disappearing). `undefined` previous means
+ *  "nothing to compare against yet" (first poll after mount) — reported as no changes,
+ *  since there's nothing meaningfully different to invalidate. */
+function changedPathIds(
+  previous: VersionsMap | undefined,
+  next: VersionsMap,
+): string[] {
+  if (!previous) return [];
+  const changed: string[] = [];
+  for (const pathId of new Set([
+    ...Object.keys(previous),
+    ...Object.keys(next),
+  ])) {
+    const prevEntries = previous[pathId] ?? {};
+    const nextEntries = next[pathId] ?? {};
+    const entryIds = new Set([
+      ...Object.keys(prevEntries),
+      ...Object.keys(nextEntries),
+    ]);
+    for (const entryId of entryIds) {
+      if (prevEntries[entryId] !== nextEntries[entryId]) {
+        changed.push(pathId);
+        break;
+      }
+    }
+  }
+  return changed;
+}
 
 export interface EntryWithContent extends EntryResponse {
   content?: string;
@@ -48,24 +84,60 @@ function byDayDesc(a: EntryResponse, b: EntryResponse): number {
  * cleared. This can't be TanStack's own `keepPreviousData`: `useQueries` matches array
  * slots to observers strictly by queryHash, so a changed key gets a brand-new
  * `QueryObserver` with no prior state of its own to carry over.
+ *
+ * Freshness while idle comes from one shared poll of GET /v1/entries/versions (a cheap
+ * {path_id: {entry_id: edit_id}} map) rather than each path's list query polling on its
+ * own interval — N per-path list refetches every tick become one small versions request,
+ * with only the paths whose version map actually changed getting invalidated (and thus
+ * refetched in full). The per-path list queries below keep refetchOnWindowFocus/Reconnect
+ * as an immediate correctness net; only the interval poll moves to the versions endpoint.
  */
 export function useMultiPathEntries(
   pathIds: Ref<string[]>,
   windowSize = DEFAULT_CONTENT_WINDOW,
 ) {
+  const queryClient = useQueryClient();
+
   const listResults = useQueries({
     queries: computed(() =>
       pathIds.value.map((pathId) => ({
         queryKey: ['v1', 'paths', pathId, 'entries'],
         queryFn: () => listEntries(pathId),
         enabled: !!pathId,
-        refetchInterval: 25_000,
-        refetchIntervalInBackground: false,
         refetchOnWindowFocus: true,
         refetchOnReconnect: true,
       })),
     ),
   });
+
+  const versionsQuery = useGetEntryVersions(
+    computed(() => ({ path_ids: pathIds.value })),
+    {
+      query: {
+        enabled: computed(() => pathIds.value.length > 0),
+        refetchInterval: 25_000,
+        refetchIntervalInBackground: false,
+        refetchOnWindowFocus: true,
+        refetchOnReconnect: true,
+      },
+    },
+  );
+
+  // Plain (non-reactive) memo of the last-seen versions snapshot, purely for diffing —
+  // not composable state, so it doesn't need to participate in Vue's reactivity graph.
+  let previousVersions: VersionsMap | undefined;
+  watch(
+    () => versionsQuery.data.value?.data as VersionsMap | undefined,
+    (next) => {
+      if (!next) return;
+      for (const pathId of changedPathIds(previousVersions, next)) {
+        queryClient.invalidateQueries({
+          queryKey: ['v1', 'paths', pathId, 'entries'],
+        });
+      }
+      previousVersions = next;
+    },
+  );
 
   const entryLists = computed<
     { pathId: string; entries: EntryResponse[]; isListLoading: boolean }[]

--- a/src/generated/apiClient.ts
+++ b/src/generated/apiClient.ts
@@ -35,6 +35,8 @@ import type {
   EntryResponse,
   ExportCreateRequest,
   ExportJobResponse,
+  GetEntryVersions200,
+  GetEntryVersionsParams,
   HTTPValidationError,
   HealthResponse,
   ImageCaptionUpdateRequest,
@@ -62,6 +64,97 @@ import type {
 
 import { customFetch } from '../lib/customFetch';
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
+
+export type rootResponse200 = {
+  data: unknown;
+  status: 200;
+};
+
+export type rootResponseSuccess = rootResponse200 & {
+  headers: Headers;
+};
+export type rootResponse = rootResponseSuccess;
+
+export const getRootUrl = () => {
+  return `/`;
+};
+
+/**
+ * @summary Root
+ */
+export const root = async (
+  options?: Parameters<typeof customFetch>[1],
+): Promise<rootResponse> => {
+  return customFetch<rootResponse>(getRootUrl(), {
+    ...options,
+    method: 'GET',
+  });
+};
+
+export const getRootQueryKey = () => {
+  return [] as const;
+};
+
+export const getRootQueryOptions = <
+  TData = Awaited<ReturnType<typeof root>>,
+  TError = unknown,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<Awaited<ReturnType<typeof root>>, TError, TData>
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = getRootQueryKey();
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof root>>> = ({
+    signal,
+  }) => root({ signal, ...requestOptions });
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof root>>,
+    TError,
+    TData
+  >;
+};
+
+export type RootQueryResult = NonNullable<Awaited<ReturnType<typeof root>>>;
+export type RootQueryError = unknown;
+
+/**
+ * @summary Root
+ */
+
+export function useRoot<
+  TData = Awaited<ReturnType<typeof root>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof root>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseQueryReturnType<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getRootQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = unref(queryOptions).queryKey as DataTag<
+    QueryKey,
+    TData,
+    TError
+  >;
+
+  return query;
+}
 
 export type healthResponse200 = {
   data: HealthResponse;
@@ -153,6 +246,2622 @@ export function useHealth<
 
   return query;
 }
+
+export type createDeletionRequestResponse200 = {
+  data: DeletionRequestResponse;
+  status: 200;
+};
+
+export type createDeletionRequestResponseSuccess =
+  createDeletionRequestResponse200 & {
+    headers: Headers;
+  };
+export type createDeletionRequestResponse =
+  createDeletionRequestResponseSuccess;
+
+export const getCreateDeletionRequestUrl = () => {
+  return `/v1/account/deletion-requests`;
+};
+
+/**
+ * @summary Create Deletion Request
+ */
+export const createDeletionRequest = async (
+  options?: Parameters<typeof customFetch>[1],
+): Promise<createDeletionRequestResponse> => {
+  return customFetch<createDeletionRequestResponse>(
+    getCreateDeletionRequestUrl(),
+    {
+      ...options,
+      method: 'POST',
+    },
+  );
+};
+
+export const getCreateDeletionRequestMutationOptions = <
+  TError = unknown,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof createDeletionRequest>>,
+    TError,
+    void,
+    TContext
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof createDeletionRequest>>,
+  TError,
+  void,
+  TContext
+> => {
+  const mutationKey = ['createDeletionRequest'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof createDeletionRequest>>,
+    void
+  > = () => {
+    return createDeletionRequest(requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type CreateDeletionRequestMutationResult = NonNullable<
+  Awaited<ReturnType<typeof createDeletionRequest>>
+>;
+
+export type CreateDeletionRequestMutationError = unknown;
+
+/**
+ * @summary Create Deletion Request
+ */
+export const useCreateDeletionRequest = <TError = unknown, TContext = unknown>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof createDeletionRequest>>,
+      TError,
+      void,
+      TContext
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseMutationReturnType<
+  Awaited<ReturnType<typeof createDeletionRequest>>,
+  TError,
+  void,
+  TContext
+> => {
+  return useMutation(
+    getCreateDeletionRequestMutationOptions(options),
+    queryClient,
+  );
+};
+
+export type getLatestDeletionRequestResponse200 = {
+  data: DeletionRequestResponse;
+  status: 200;
+};
+
+export type getLatestDeletionRequestResponseSuccess =
+  getLatestDeletionRequestResponse200 & {
+    headers: Headers;
+  };
+export type getLatestDeletionRequestResponse =
+  getLatestDeletionRequestResponseSuccess;
+
+export const getGetLatestDeletionRequestUrl = () => {
+  return `/v1/account/deletion-requests/latest`;
+};
+
+/**
+ * @summary Latest Deletion Request
+ */
+export const getLatestDeletionRequest = async (
+  options?: Parameters<typeof customFetch>[1],
+): Promise<getLatestDeletionRequestResponse> => {
+  return customFetch<getLatestDeletionRequestResponse>(
+    getGetLatestDeletionRequestUrl(),
+    {
+      ...options,
+      method: 'GET',
+    },
+  );
+};
+
+export const getGetLatestDeletionRequestQueryKey = () => {
+  return ['v1', 'account', 'deletion-requests', 'latest'] as const;
+};
+
+export const getGetLatestDeletionRequestQueryOptions = <
+  TData = Awaited<ReturnType<typeof getLatestDeletionRequest>>,
+  TError = unknown,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<
+      Awaited<ReturnType<typeof getLatestDeletionRequest>>,
+      TError,
+      TData
+    >
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = getGetLatestDeletionRequestQueryKey();
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof getLatestDeletionRequest>>
+  > = ({ signal }) => getLatestDeletionRequest({ signal, ...requestOptions });
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getLatestDeletionRequest>>,
+    TError,
+    TData
+  >;
+};
+
+export type GetLatestDeletionRequestQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getLatestDeletionRequest>>
+>;
+export type GetLatestDeletionRequestQueryError = unknown;
+
+/**
+ * @summary Latest Deletion Request
+ */
+
+export function useGetLatestDeletionRequest<
+  TData = Awaited<ReturnType<typeof getLatestDeletionRequest>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getLatestDeletionRequest>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseQueryReturnType<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetLatestDeletionRequestQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = unref(queryOptions).queryKey as DataTag<
+    QueryKey,
+    TData,
+    TError
+  >;
+
+  return query;
+}
+
+export type updateDisplayNameResponse200 = {
+  data: UserProfileResponse;
+  status: 200;
+};
+
+export type updateDisplayNameResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type updateDisplayNameResponseSuccess = updateDisplayNameResponse200 & {
+  headers: Headers;
+};
+export type updateDisplayNameResponseError = updateDisplayNameResponse422 & {
+  headers: Headers;
+};
+
+export type updateDisplayNameResponse =
+  updateDisplayNameResponseSuccess | updateDisplayNameResponseError;
+
+export const getUpdateDisplayNameUrl = () => {
+  return `/v1/account/display-name`;
+};
+
+/**
+ * @summary Update Display Name
+ */
+export const updateDisplayName = async (
+  userDisplayNameUpdateRequest: UserDisplayNameUpdateRequest,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<updateDisplayNameResponse> => {
+  return customFetch<updateDisplayNameResponse>(getUpdateDisplayNameUrl(), {
+    ...options,
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(userDisplayNameUpdateRequest),
+  });
+};
+
+export const getUpdateDisplayNameMutationOptions = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof updateDisplayName>>,
+    TError,
+    { data: UserDisplayNameUpdateRequest },
+    TContext
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof updateDisplayName>>,
+  TError,
+  { data: UserDisplayNameUpdateRequest },
+  TContext
+> => {
+  const mutationKey = ['updateDisplayName'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof updateDisplayName>>,
+    { data: UserDisplayNameUpdateRequest }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return updateDisplayName(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type UpdateDisplayNameMutationResult = NonNullable<
+  Awaited<ReturnType<typeof updateDisplayName>>
+>;
+export type UpdateDisplayNameMutationBody = UserDisplayNameUpdateRequest;
+export type UpdateDisplayNameMutationError = HTTPValidationError;
+
+/**
+ * @summary Update Display Name
+ */
+export const useUpdateDisplayName = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof updateDisplayName>>,
+      TError,
+      { data: UserDisplayNameUpdateRequest },
+      TContext
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseMutationReturnType<
+  Awaited<ReturnType<typeof updateDisplayName>>,
+  TError,
+  { data: UserDisplayNameUpdateRequest },
+  TContext
+> => {
+  return useMutation(getUpdateDisplayNameMutationOptions(options), queryClient);
+};
+
+export type getProfileResponse200 = {
+  data: UserProfileResponse;
+  status: 200;
+};
+
+export type getProfileResponseSuccess = getProfileResponse200 & {
+  headers: Headers;
+};
+export type getProfileResponse = getProfileResponseSuccess;
+
+export const getGetProfileUrl = () => {
+  return `/v1/account/profile`;
+};
+
+/**
+ * @summary Get Profile
+ */
+export const getProfile = async (
+  options?: Parameters<typeof customFetch>[1],
+): Promise<getProfileResponse> => {
+  return customFetch<getProfileResponse>(getGetProfileUrl(), {
+    ...options,
+    method: 'GET',
+  });
+};
+
+export const getGetProfileQueryKey = () => {
+  return ['v1', 'account', 'profile'] as const;
+};
+
+export const getGetProfileQueryOptions = <
+  TData = Awaited<ReturnType<typeof getProfile>>,
+  TError = unknown,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<Awaited<ReturnType<typeof getProfile>>, TError, TData>
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = getGetProfileQueryKey();
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getProfile>>> = ({
+    signal,
+  }) => getProfile({ signal, ...requestOptions });
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getProfile>>,
+    TError,
+    TData
+  >;
+};
+
+export type GetProfileQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getProfile>>
+>;
+export type GetProfileQueryError = unknown;
+
+/**
+ * @summary Get Profile
+ */
+
+export function useGetProfile<
+  TData = Awaited<ReturnType<typeof getProfile>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getProfile>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseQueryReturnType<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetProfileQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = unref(queryOptions).queryKey as DataTag<
+    QueryKey,
+    TData,
+    TError
+  >;
+
+  return query;
+}
+
+export type updateSettingsResponse200 = {
+  data: UserProfileResponse;
+  status: 200;
+};
+
+export type updateSettingsResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type updateSettingsResponseSuccess = updateSettingsResponse200 & {
+  headers: Headers;
+};
+export type updateSettingsResponseError = updateSettingsResponse422 & {
+  headers: Headers;
+};
+
+export type updateSettingsResponse =
+  updateSettingsResponseSuccess | updateSettingsResponseError;
+
+export const getUpdateSettingsUrl = () => {
+  return `/v1/account/settings`;
+};
+
+/**
+ * @summary Update Settings
+ */
+export const updateSettings = async (
+  userSettingsUpdateRequest: UserSettingsUpdateRequest,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<updateSettingsResponse> => {
+  return customFetch<updateSettingsResponse>(getUpdateSettingsUrl(), {
+    ...options,
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(userSettingsUpdateRequest),
+  });
+};
+
+export const getUpdateSettingsMutationOptions = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof updateSettings>>,
+    TError,
+    { data: UserSettingsUpdateRequest },
+    TContext
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof updateSettings>>,
+  TError,
+  { data: UserSettingsUpdateRequest },
+  TContext
+> => {
+  const mutationKey = ['updateSettings'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof updateSettings>>,
+    { data: UserSettingsUpdateRequest }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return updateSettings(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type UpdateSettingsMutationResult = NonNullable<
+  Awaited<ReturnType<typeof updateSettings>>
+>;
+export type UpdateSettingsMutationBody = UserSettingsUpdateRequest;
+export type UpdateSettingsMutationError = HTTPValidationError;
+
+/**
+ * @summary Update Settings
+ */
+export const useUpdateSettings = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof updateSettings>>,
+      TError,
+      { data: UserSettingsUpdateRequest },
+      TContext
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseMutationReturnType<
+  Awaited<ReturnType<typeof updateSettings>>,
+  TError,
+  { data: UserSettingsUpdateRequest },
+  TContext
+> => {
+  return useMutation(getUpdateSettingsMutationOptions(options), queryClient);
+};
+
+export type adminLoginResponse200 = {
+  data: AdminLoginResponse;
+  status: 200;
+};
+
+export type adminLoginResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type adminLoginResponseSuccess = adminLoginResponse200 & {
+  headers: Headers;
+};
+export type adminLoginResponseError = adminLoginResponse422 & {
+  headers: Headers;
+};
+
+export type adminLoginResponse =
+  adminLoginResponseSuccess | adminLoginResponseError;
+
+export const getAdminLoginUrl = () => {
+  return `/v1/admin/login`;
+};
+
+/**
+ * @summary Admin Login
+ */
+export const adminLogin = async (
+  adminLoginRequest: AdminLoginRequest,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<adminLoginResponse> => {
+  return customFetch<adminLoginResponse>(getAdminLoginUrl(), {
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(adminLoginRequest),
+  });
+};
+
+export const getAdminLoginMutationOptions = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof adminLogin>>,
+    TError,
+    { data: AdminLoginRequest },
+    TContext
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof adminLogin>>,
+  TError,
+  { data: AdminLoginRequest },
+  TContext
+> => {
+  const mutationKey = ['adminLogin'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof adminLogin>>,
+    { data: AdminLoginRequest }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return adminLogin(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type AdminLoginMutationResult = NonNullable<
+  Awaited<ReturnType<typeof adminLogin>>
+>;
+export type AdminLoginMutationBody = AdminLoginRequest;
+export type AdminLoginMutationError = HTTPValidationError;
+
+/**
+ * @summary Admin Login
+ */
+export const useAdminLogin = <TError = HTTPValidationError, TContext = unknown>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof adminLogin>>,
+      TError,
+      { data: AdminLoginRequest },
+      TContext
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseMutationReturnType<
+  Awaited<ReturnType<typeof adminLogin>>,
+  TError,
+  { data: AdminLoginRequest },
+  TContext
+> => {
+  return useMutation(getAdminLoginMutationOptions(options), queryClient);
+};
+
+export type setPathCreationApprovalResponse200 = {
+  data: PathCreationApprovalResponse;
+  status: 200;
+};
+
+export type setPathCreationApprovalResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type setPathCreationApprovalResponseSuccess =
+  setPathCreationApprovalResponse200 & {
+    headers: Headers;
+  };
+export type setPathCreationApprovalResponseError =
+  setPathCreationApprovalResponse422 & {
+    headers: Headers;
+  };
+
+export type setPathCreationApprovalResponse =
+  setPathCreationApprovalResponseSuccess | setPathCreationApprovalResponseError;
+
+export const getSetPathCreationApprovalUrl = (userId: string) => {
+  return `/v1/admin/users/${userId}/path-creation-approval`;
+};
+
+/**
+ * @summary Set Path Creation Approval
+ */
+export const setPathCreationApproval = async (
+  userId: string,
+  pathCreationApprovalRequest: PathCreationApprovalRequest,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<setPathCreationApprovalResponse> => {
+  return customFetch<setPathCreationApprovalResponse>(
+    getSetPathCreationApprovalUrl(userId),
+    {
+      ...options,
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', ...options?.headers },
+      body: JSON.stringify(pathCreationApprovalRequest),
+    },
+  );
+};
+
+export const getSetPathCreationApprovalMutationOptions = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof setPathCreationApproval>>,
+    TError,
+    { userId: string; data: PathCreationApprovalRequest },
+    TContext
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof setPathCreationApproval>>,
+  TError,
+  { userId: string; data: PathCreationApprovalRequest },
+  TContext
+> => {
+  const mutationKey = ['setPathCreationApproval'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof setPathCreationApproval>>,
+    { userId: string; data: PathCreationApprovalRequest }
+  > = (props) => {
+    const { userId, data } = props ?? {};
+
+    return setPathCreationApproval(userId, data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type SetPathCreationApprovalMutationResult = NonNullable<
+  Awaited<ReturnType<typeof setPathCreationApproval>>
+>;
+export type SetPathCreationApprovalMutationBody = PathCreationApprovalRequest;
+export type SetPathCreationApprovalMutationError = HTTPValidationError;
+
+/**
+ * @summary Set Path Creation Approval
+ */
+export const useSetPathCreationApproval = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof setPathCreationApproval>>,
+      TError,
+      { userId: string; data: PathCreationApprovalRequest },
+      TContext
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseMutationReturnType<
+  Awaited<ReturnType<typeof setPathCreationApproval>>,
+  TError,
+  { userId: string; data: PathCreationApprovalRequest },
+  TContext
+> => {
+  return useMutation(
+    getSetPathCreationApprovalMutationOptions(options),
+    queryClient,
+  );
+};
+
+export type authCallbackRedirectResponse200 = {
+  data: OAuthCallbackResponse;
+  status: 200;
+};
+
+export type authCallbackRedirectResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type authCallbackRedirectResponseSuccess =
+  authCallbackRedirectResponse200 & {
+    headers: Headers;
+  };
+export type authCallbackRedirectResponseError =
+  authCallbackRedirectResponse422 & {
+    headers: Headers;
+  };
+
+export type authCallbackRedirectResponse =
+  authCallbackRedirectResponseSuccess | authCallbackRedirectResponseError;
+
+export const getAuthCallbackRedirectUrl = (
+  params: AuthCallbackRedirectParams,
+) => {
+  const normalizedParams = new URLSearchParams();
+
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? 'null' : String(value));
+    }
+  });
+
+  const stringifiedParams = normalizedParams.toString();
+
+  return stringifiedParams.length > 0
+    ? `/v1/auth/callback?${stringifiedParams}`
+    : `/v1/auth/callback`;
+};
+
+/**
+ * Handle GET OAuth callback when the backend is the redirect target.
+ *
+ * The callback_uri is extracted from the signed state token rather than
+ * passed as a query parameter, so it is guaranteed to match the value used
+ * during the original login request.
+ * @summary Oauth Callback Get
+ */
+export const authCallbackRedirect = async (
+  params: AuthCallbackRedirectParams,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<authCallbackRedirectResponse> => {
+  return customFetch<authCallbackRedirectResponse>(
+    getAuthCallbackRedirectUrl(params),
+    {
+      ...options,
+      method: 'GET',
+    },
+  );
+};
+
+export const getAuthCallbackRedirectQueryKey = (
+  params?: MaybeRefOrGetter<AuthCallbackRedirectParams>,
+) => {
+  return ['v1', 'auth', 'callback', ...(params ? [params] : [])] as const;
+};
+
+export const getAuthCallbackRedirectQueryOptions = <
+  TData = Awaited<ReturnType<typeof authCallbackRedirect>>,
+  TError = HTTPValidationError,
+>(
+  params: MaybeRefOrGetter<AuthCallbackRedirectParams>,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof authCallbackRedirect>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = getAuthCallbackRedirectQueryKey(params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof authCallbackRedirect>>
+  > = ({ signal }) =>
+    authCallbackRedirect(toValue(params), { signal, ...requestOptions });
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof authCallbackRedirect>>,
+    TError,
+    TData
+  >;
+};
+
+export type AuthCallbackRedirectQueryResult = NonNullable<
+  Awaited<ReturnType<typeof authCallbackRedirect>>
+>;
+export type AuthCallbackRedirectQueryError = HTTPValidationError;
+
+/**
+ * @summary Oauth Callback Get
+ */
+
+export function useAuthCallbackRedirect<
+  TData = Awaited<ReturnType<typeof authCallbackRedirect>>,
+  TError = HTTPValidationError,
+>(
+  params: MaybeRefOrGetter<AuthCallbackRedirectParams>,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof authCallbackRedirect>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseQueryReturnType<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getAuthCallbackRedirectQueryOptions(params, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = unref(queryOptions).queryKey as DataTag<
+    QueryKey,
+    TData,
+    TError
+  >;
+
+  return query;
+}
+
+export type authCallbackResponse200 = {
+  data: OAuthCallbackResponse;
+  status: 200;
+};
+
+export type authCallbackResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type authCallbackResponseSuccess = authCallbackResponse200 & {
+  headers: Headers;
+};
+export type authCallbackResponseError = authCallbackResponse422 & {
+  headers: Headers;
+};
+
+export type authCallbackResponse =
+  authCallbackResponseSuccess | authCallbackResponseError;
+
+export const getAuthCallbackUrl = () => {
+  return `/v1/auth/callback`;
+};
+
+/**
+ * Exchange the OAuth code for a user session token.
+ * @summary Oauth Callback
+ */
+export const authCallback = async (
+  oAuthCallbackRequest: OAuthCallbackRequest,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<authCallbackResponse> => {
+  return customFetch<authCallbackResponse>(getAuthCallbackUrl(), {
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(oAuthCallbackRequest),
+  });
+};
+
+export const getAuthCallbackMutationOptions = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof authCallback>>,
+    TError,
+    { data: OAuthCallbackRequest },
+    TContext
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof authCallback>>,
+  TError,
+  { data: OAuthCallbackRequest },
+  TContext
+> => {
+  const mutationKey = ['authCallback'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof authCallback>>,
+    { data: OAuthCallbackRequest }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return authCallback(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type AuthCallbackMutationResult = NonNullable<
+  Awaited<ReturnType<typeof authCallback>>
+>;
+export type AuthCallbackMutationBody = OAuthCallbackRequest;
+export type AuthCallbackMutationError = HTTPValidationError;
+
+/**
+ * @summary Oauth Callback
+ */
+export const useAuthCallback = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof authCallback>>,
+      TError,
+      { data: OAuthCallbackRequest },
+      TContext
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseMutationReturnType<
+  Awaited<ReturnType<typeof authCallback>>,
+  TError,
+  { data: OAuthCallbackRequest },
+  TContext
+> => {
+  return useMutation(getAuthCallbackMutationOptions(options), queryClient);
+};
+
+export type authLoginResponse200 = {
+  data: OAuthLoginResponse;
+  status: 200;
+};
+
+export type authLoginResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type authLoginResponseSuccess = authLoginResponse200 & {
+  headers: Headers;
+};
+export type authLoginResponseError = authLoginResponse422 & {
+  headers: Headers;
+};
+
+export type authLoginResponse =
+  authLoginResponseSuccess | authLoginResponseError;
+
+export const getAuthLoginUrl = (params: AuthLoginParams) => {
+  const normalizedParams = new URLSearchParams();
+
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? 'null' : String(value));
+    }
+  });
+
+  const stringifiedParams = normalizedParams.toString();
+
+  return stringifiedParams.length > 0
+    ? `/v1/auth/login?${stringifiedParams}`
+    : `/v1/auth/login`;
+};
+
+/**
+ * Return the Google OAuth authorization URL for the given callback URI.
+ * @summary Oauth Login
+ */
+export const authLogin = async (
+  params: AuthLoginParams,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<authLoginResponse> => {
+  return customFetch<authLoginResponse>(getAuthLoginUrl(params), {
+    ...options,
+    method: 'GET',
+  });
+};
+
+export const getAuthLoginQueryKey = (
+  params?: MaybeRefOrGetter<AuthLoginParams>,
+) => {
+  return ['v1', 'auth', 'login', ...(params ? [params] : [])] as const;
+};
+
+export const getAuthLoginQueryOptions = <
+  TData = Awaited<ReturnType<typeof authLogin>>,
+  TError = HTTPValidationError,
+>(
+  params: MaybeRefOrGetter<AuthLoginParams>,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof authLogin>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = getAuthLoginQueryKey(params);
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof authLogin>>> = ({
+    signal,
+  }) => authLogin(toValue(params), { signal, ...requestOptions });
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof authLogin>>,
+    TError,
+    TData
+  >;
+};
+
+export type AuthLoginQueryResult = NonNullable<
+  Awaited<ReturnType<typeof authLogin>>
+>;
+export type AuthLoginQueryError = HTTPValidationError;
+
+/**
+ * @summary Oauth Login
+ */
+
+export function useAuthLogin<
+  TData = Awaited<ReturnType<typeof authLogin>>,
+  TError = HTTPValidationError,
+>(
+  params: MaybeRefOrGetter<AuthLoginParams>,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof authLogin>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseQueryReturnType<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getAuthLoginQueryOptions(params, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = unref(queryOptions).queryKey as DataTag<
+    QueryKey,
+    TData,
+    TError
+  >;
+
+  return query;
+}
+
+export type getEntryVersionsResponse200 = {
+  data: GetEntryVersions200;
+  status: 200;
+};
+
+export type getEntryVersionsResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type getEntryVersionsResponseSuccess = getEntryVersionsResponse200 & {
+  headers: Headers;
+};
+export type getEntryVersionsResponseError = getEntryVersionsResponse422 & {
+  headers: Headers;
+};
+
+export type getEntryVersionsResponse =
+  getEntryVersionsResponseSuccess | getEntryVersionsResponseError;
+
+export const getGetEntryVersionsUrl = (params?: GetEntryVersionsParams) => {
+  const normalizedParams = new URLSearchParams();
+
+  Object.entries(params || {}).forEach(([key, value]) => {
+    const explodeParameters = ['path_ids'];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : String(v));
+      });
+      return;
+    }
+  });
+
+  const stringifiedParams = normalizedParams.toString();
+
+  return stringifiedParams.length > 0
+    ? `/v1/entries/versions?${stringifiedParams}`
+    : `/v1/entries/versions`;
+};
+
+/**
+ * Cheap {path_id: {entry_id: edit_id}} map for polling many paths at once.
+ *
+ * A dedicated round trip so pollers can diff versions and only fetch full
+ * entry content for what actually changed, instead of re-fetching every
+ * path's full entry list on every tick.
+ *
+ * Unknown or inaccessible path_ids are silently omitted rather than
+ * failing the whole request — same as a caller not being subscribed to a
+ * path simply not seeing it in list_paths.
+ * @summary Get Entry Versions
+ */
+export const getEntryVersions = async (
+  params?: GetEntryVersionsParams,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<getEntryVersionsResponse> => {
+  return customFetch<getEntryVersionsResponse>(getGetEntryVersionsUrl(params), {
+    ...options,
+    method: 'GET',
+  });
+};
+
+export const getGetEntryVersionsQueryKey = (
+  params?: MaybeRefOrGetter<GetEntryVersionsParams>,
+) => {
+  return ['v1', 'entries', 'versions', ...(params ? [params] : [])] as const;
+};
+
+export const getGetEntryVersionsQueryOptions = <
+  TData = Awaited<ReturnType<typeof getEntryVersions>>,
+  TError = HTTPValidationError,
+>(
+  params?: MaybeRefOrGetter<GetEntryVersionsParams>,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getEntryVersions>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = getGetEntryVersionsQueryKey(params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof getEntryVersions>>
+  > = ({ signal }) =>
+    getEntryVersions(toValue(params), { signal, ...requestOptions });
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getEntryVersions>>,
+    TError,
+    TData
+  >;
+};
+
+export type GetEntryVersionsQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getEntryVersions>>
+>;
+export type GetEntryVersionsQueryError = HTTPValidationError;
+
+/**
+ * @summary Get Entry Versions
+ */
+
+export function useGetEntryVersions<
+  TData = Awaited<ReturnType<typeof getEntryVersions>>,
+  TError = HTTPValidationError,
+>(
+  params?: MaybeRefOrGetter<GetEntryVersionsParams>,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getEntryVersions>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseQueryReturnType<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetEntryVersionsQueryOptions(params, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = unref(queryOptions).queryKey as DataTag<
+    QueryKey,
+    TData,
+    TError
+  >;
+
+  return query;
+}
+
+export type createExportResponse202 = {
+  data: ExportJobResponse;
+  status: 202;
+};
+
+export type createExportResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type createExportResponseSuccess = createExportResponse202 & {
+  headers: Headers;
+};
+export type createExportResponseError = createExportResponse422 & {
+  headers: Headers;
+};
+
+export type createExportResponse =
+  createExportResponseSuccess | createExportResponseError;
+
+export const getCreateExportUrl = () => {
+  return `/v1/exports`;
+};
+
+/**
+ * @summary Create Export
+ */
+export const createExport = async (
+  exportCreateRequest: ExportCreateRequest,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<createExportResponse> => {
+  return customFetch<createExportResponse>(getCreateExportUrl(), {
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(exportCreateRequest),
+  });
+};
+
+export const getCreateExportMutationOptions = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof createExport>>,
+    TError,
+    { data: ExportCreateRequest },
+    TContext
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof createExport>>,
+  TError,
+  { data: ExportCreateRequest },
+  TContext
+> => {
+  const mutationKey = ['createExport'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof createExport>>,
+    { data: ExportCreateRequest }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return createExport(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type CreateExportMutationResult = NonNullable<
+  Awaited<ReturnType<typeof createExport>>
+>;
+export type CreateExportMutationBody = ExportCreateRequest;
+export type CreateExportMutationError = HTTPValidationError;
+
+/**
+ * @summary Create Export
+ */
+export const useCreateExport = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof createExport>>,
+      TError,
+      { data: ExportCreateRequest },
+      TContext
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseMutationReturnType<
+  Awaited<ReturnType<typeof createExport>>,
+  TError,
+  { data: ExportCreateRequest },
+  TContext
+> => {
+  return useMutation(getCreateExportMutationOptions(options), queryClient);
+};
+
+export type getExportResponse200 = {
+  data: ExportJobResponse;
+  status: 200;
+};
+
+export type getExportResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type getExportResponseSuccess = getExportResponse200 & {
+  headers: Headers;
+};
+export type getExportResponseError = getExportResponse422 & {
+  headers: Headers;
+};
+
+export type getExportResponse =
+  getExportResponseSuccess | getExportResponseError;
+
+export const getGetExportUrl = (exportId: string) => {
+  return `/v1/exports/${exportId}`;
+};
+
+/**
+ * @summary Get Export
+ */
+export const getExport = async (
+  exportId: string,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<getExportResponse> => {
+  return customFetch<getExportResponse>(getGetExportUrl(exportId), {
+    ...options,
+    method: 'GET',
+  });
+};
+
+export const getGetExportQueryKey = (exportId: MaybeRefOrGetter<string>) => {
+  return ['v1', 'exports', exportId] as const;
+};
+
+export const getGetExportQueryOptions = <
+  TData = Awaited<ReturnType<typeof getExport>>,
+  TError = HTTPValidationError,
+>(
+  exportId: MaybeRefOrGetter<string>,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getExport>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = getGetExportQueryKey(exportId);
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getExport>>> = ({
+    signal,
+  }) => getExport(toValue(exportId), { signal, ...requestOptions });
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: computed(
+      () => toValue(exportId) !== null && toValue(exportId) !== undefined,
+    ),
+    ...queryOptions,
+  } as UseQueryOptions<Awaited<ReturnType<typeof getExport>>, TError, TData>;
+};
+
+export type GetExportQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getExport>>
+>;
+export type GetExportQueryError = HTTPValidationError;
+
+/**
+ * @summary Get Export
+ */
+
+export function useGetExport<
+  TData = Awaited<ReturnType<typeof getExport>>,
+  TError = HTTPValidationError,
+>(
+  exportId: MaybeRefOrGetter<string>,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getExport>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseQueryReturnType<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetExportQueryOptions(exportId, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = unref(queryOptions).queryKey as DataTag<
+    QueryKey,
+    TData,
+    TError
+  >;
+
+  return query;
+}
+
+export type downloadExportImagesResponse200 = {
+  data: DownloadURLResponse;
+  status: 200;
+};
+
+export type downloadExportImagesResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type downloadExportImagesResponseSuccess =
+  downloadExportImagesResponse200 & {
+    headers: Headers;
+  };
+export type downloadExportImagesResponseError =
+  downloadExportImagesResponse422 & {
+    headers: Headers;
+  };
+
+export type downloadExportImagesResponse =
+  downloadExportImagesResponseSuccess | downloadExportImagesResponseError;
+
+export const getDownloadExportImagesUrl = (exportId: string) => {
+  return `/v1/exports/${exportId}/download/images`;
+};
+
+/**
+ * @summary Download Images
+ */
+export const downloadExportImages = async (
+  exportId: string,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<downloadExportImagesResponse> => {
+  return customFetch<downloadExportImagesResponse>(
+    getDownloadExportImagesUrl(exportId),
+    {
+      ...options,
+      method: 'GET',
+    },
+  );
+};
+
+export const getDownloadExportImagesQueryKey = (
+  exportId: MaybeRefOrGetter<string>,
+) => {
+  return ['v1', 'exports', exportId, 'download', 'images'] as const;
+};
+
+export const getDownloadExportImagesQueryOptions = <
+  TData = Awaited<ReturnType<typeof downloadExportImages>>,
+  TError = HTTPValidationError,
+>(
+  exportId: MaybeRefOrGetter<string>,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof downloadExportImages>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = getDownloadExportImagesQueryKey(exportId);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof downloadExportImages>>
+  > = ({ signal }) =>
+    downloadExportImages(toValue(exportId), { signal, ...requestOptions });
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: computed(
+      () => toValue(exportId) !== null && toValue(exportId) !== undefined,
+    ),
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof downloadExportImages>>,
+    TError,
+    TData
+  >;
+};
+
+export type DownloadExportImagesQueryResult = NonNullable<
+  Awaited<ReturnType<typeof downloadExportImages>>
+>;
+export type DownloadExportImagesQueryError = HTTPValidationError;
+
+/**
+ * @summary Download Images
+ */
+
+export function useDownloadExportImages<
+  TData = Awaited<ReturnType<typeof downloadExportImages>>,
+  TError = HTTPValidationError,
+>(
+  exportId: MaybeRefOrGetter<string>,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof downloadExportImages>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseQueryReturnType<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getDownloadExportImagesQueryOptions(exportId, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = unref(queryOptions).queryKey as DataTag<
+    QueryKey,
+    TData,
+    TError
+  >;
+
+  return query;
+}
+
+export type downloadExportJsonResponse200 = {
+  data: DownloadURLResponse;
+  status: 200;
+};
+
+export type downloadExportJsonResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type downloadExportJsonResponseSuccess =
+  downloadExportJsonResponse200 & {
+    headers: Headers;
+  };
+export type downloadExportJsonResponseError = downloadExportJsonResponse422 & {
+  headers: Headers;
+};
+
+export type downloadExportJsonResponse =
+  downloadExportJsonResponseSuccess | downloadExportJsonResponseError;
+
+export const getDownloadExportJsonUrl = (exportId: string) => {
+  return `/v1/exports/${exportId}/download/json`;
+};
+
+/**
+ * @summary Download Json
+ */
+export const downloadExportJson = async (
+  exportId: string,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<downloadExportJsonResponse> => {
+  return customFetch<downloadExportJsonResponse>(
+    getDownloadExportJsonUrl(exportId),
+    {
+      ...options,
+      method: 'GET',
+    },
+  );
+};
+
+export const getDownloadExportJsonQueryKey = (
+  exportId: MaybeRefOrGetter<string>,
+) => {
+  return ['v1', 'exports', exportId, 'download', 'json'] as const;
+};
+
+export const getDownloadExportJsonQueryOptions = <
+  TData = Awaited<ReturnType<typeof downloadExportJson>>,
+  TError = HTTPValidationError,
+>(
+  exportId: MaybeRefOrGetter<string>,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof downloadExportJson>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = getDownloadExportJsonQueryKey(exportId);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof downloadExportJson>>
+  > = ({ signal }) =>
+    downloadExportJson(toValue(exportId), { signal, ...requestOptions });
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: computed(
+      () => toValue(exportId) !== null && toValue(exportId) !== undefined,
+    ),
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof downloadExportJson>>,
+    TError,
+    TData
+  >;
+};
+
+export type DownloadExportJsonQueryResult = NonNullable<
+  Awaited<ReturnType<typeof downloadExportJson>>
+>;
+export type DownloadExportJsonQueryError = HTTPValidationError;
+
+/**
+ * @summary Download Json
+ */
+
+export function useDownloadExportJson<
+  TData = Awaited<ReturnType<typeof downloadExportJson>>,
+  TError = HTTPValidationError,
+>(
+  exportId: MaybeRefOrGetter<string>,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof downloadExportJson>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseQueryReturnType<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getDownloadExportJsonQueryOptions(exportId, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = unref(queryOptions).queryKey as DataTag<
+    QueryKey,
+    TData,
+    TError
+  >;
+
+  return query;
+}
+
+export type updateImageCaptionResponse200 = {
+  data: ImageCaptionUpdateResponse;
+  status: 200;
+};
+
+export type updateImageCaptionResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type updateImageCaptionResponseSuccess =
+  updateImageCaptionResponse200 & {
+    headers: Headers;
+  };
+export type updateImageCaptionResponseError = updateImageCaptionResponse422 & {
+  headers: Headers;
+};
+
+export type updateImageCaptionResponse =
+  updateImageCaptionResponseSuccess | updateImageCaptionResponseError;
+
+export const getUpdateImageCaptionUrl = (imageId: string) => {
+  return `/v1/images/${imageId}`;
+};
+
+/**
+ * @summary Update Image Caption
+ */
+export const updateImageCaption = async (
+  imageId: string,
+  imageCaptionUpdateRequest: ImageCaptionUpdateRequest,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<updateImageCaptionResponse> => {
+  return customFetch<updateImageCaptionResponse>(
+    getUpdateImageCaptionUrl(imageId),
+    {
+      ...options,
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...options?.headers },
+      body: JSON.stringify(imageCaptionUpdateRequest),
+    },
+  );
+};
+
+export const getUpdateImageCaptionMutationOptions = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof updateImageCaption>>,
+    TError,
+    { imageId: string; data: ImageCaptionUpdateRequest },
+    TContext
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof updateImageCaption>>,
+  TError,
+  { imageId: string; data: ImageCaptionUpdateRequest },
+  TContext
+> => {
+  const mutationKey = ['updateImageCaption'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof updateImageCaption>>,
+    { imageId: string; data: ImageCaptionUpdateRequest }
+  > = (props) => {
+    const { imageId, data } = props ?? {};
+
+    return updateImageCaption(imageId, data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type UpdateImageCaptionMutationResult = NonNullable<
+  Awaited<ReturnType<typeof updateImageCaption>>
+>;
+export type UpdateImageCaptionMutationBody = ImageCaptionUpdateRequest;
+export type UpdateImageCaptionMutationError = HTTPValidationError;
+
+/**
+ * @summary Update Image Caption
+ */
+export const useUpdateImageCaption = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof updateImageCaption>>,
+      TError,
+      { imageId: string; data: ImageCaptionUpdateRequest },
+      TContext
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseMutationReturnType<
+  Awaited<ReturnType<typeof updateImageCaption>>,
+  TError,
+  { imageId: string; data: ImageCaptionUpdateRequest },
+  TContext
+> => {
+  return useMutation(
+    getUpdateImageCaptionMutationOptions(options),
+    queryClient,
+  );
+};
+
+export type getImageDownloadUrlResponse200 = {
+  data: ImageDownloadResponse;
+  status: 200;
+};
+
+export type getImageDownloadUrlResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type getImageDownloadUrlResponseSuccess =
+  getImageDownloadUrlResponse200 & {
+    headers: Headers;
+  };
+export type getImageDownloadUrlResponseError =
+  getImageDownloadUrlResponse422 & {
+    headers: Headers;
+  };
+
+export type getImageDownloadUrlResponse =
+  getImageDownloadUrlResponseSuccess | getImageDownloadUrlResponseError;
+
+export const getGetImageDownloadUrlUrl = (imageId: string) => {
+  return `/v1/images/${imageId}/download-url`;
+};
+
+/**
+ * @summary Get Image Download Url
+ */
+export const getImageDownloadUrl = async (
+  imageId: string,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<getImageDownloadUrlResponse> => {
+  return customFetch<getImageDownloadUrlResponse>(
+    getGetImageDownloadUrlUrl(imageId),
+    {
+      ...options,
+      method: 'GET',
+    },
+  );
+};
+
+export const getGetImageDownloadUrlQueryKey = (
+  imageId: MaybeRefOrGetter<string>,
+) => {
+  return ['v1', 'images', imageId, 'download-url'] as const;
+};
+
+export const getGetImageDownloadUrlQueryOptions = <
+  TData = Awaited<ReturnType<typeof getImageDownloadUrl>>,
+  TError = HTTPValidationError,
+>(
+  imageId: MaybeRefOrGetter<string>,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getImageDownloadUrl>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = getGetImageDownloadUrlQueryKey(imageId);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof getImageDownloadUrl>>
+  > = ({ signal }) =>
+    getImageDownloadUrl(toValue(imageId), { signal, ...requestOptions });
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: computed(
+      () => toValue(imageId) !== null && toValue(imageId) !== undefined,
+    ),
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof getImageDownloadUrl>>,
+    TError,
+    TData
+  >;
+};
+
+export type GetImageDownloadUrlQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getImageDownloadUrl>>
+>;
+export type GetImageDownloadUrlQueryError = HTTPValidationError;
+
+/**
+ * @summary Get Image Download Url
+ */
+
+export function useGetImageDownloadUrl<
+  TData = Awaited<ReturnType<typeof getImageDownloadUrl>>,
+  TError = HTTPValidationError,
+>(
+  imageId: MaybeRefOrGetter<string>,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getImageDownloadUrl>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseQueryReturnType<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetImageDownloadUrlQueryOptions(imageId, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = unref(queryOptions).queryKey as DataTag<
+    QueryKey,
+    TData,
+    TError
+  >;
+
+  return query;
+}
+
+export type listInvitationsResponse200 = {
+  data: InvitationResponse[];
+  status: 200;
+};
+
+export type listInvitationsResponseSuccess = listInvitationsResponse200 & {
+  headers: Headers;
+};
+export type listInvitationsResponse = listInvitationsResponseSuccess;
+
+export const getListInvitationsUrl = () => {
+  return `/v1/invitations`;
+};
+
+/**
+ * @summary List Invitations
+ */
+export const listInvitations = async (
+  options?: Parameters<typeof customFetch>[1],
+): Promise<listInvitationsResponse> => {
+  return customFetch<listInvitationsResponse>(getListInvitationsUrl(), {
+    ...options,
+    method: 'GET',
+  });
+};
+
+export const getListInvitationsQueryKey = () => {
+  return ['v1', 'invitations'] as const;
+};
+
+export const getListInvitationsQueryOptions = <
+  TData = Awaited<ReturnType<typeof listInvitations>>,
+  TError = unknown,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<Awaited<ReturnType<typeof listInvitations>>, TError, TData>
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = getListInvitationsQueryKey();
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof listInvitations>>> = ({
+    signal,
+  }) => listInvitations({ signal, ...requestOptions });
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof listInvitations>>,
+    TError,
+    TData
+  >;
+};
+
+export type ListInvitationsQueryResult = NonNullable<
+  Awaited<ReturnType<typeof listInvitations>>
+>;
+export type ListInvitationsQueryError = unknown;
+
+/**
+ * @summary List Invitations
+ */
+
+export function useListInvitations<
+  TData = Awaited<ReturnType<typeof listInvitations>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listInvitations>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseQueryReturnType<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getListInvitationsQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = unref(queryOptions).queryKey as DataTag<
+    QueryKey,
+    TData,
+    TError
+  >;
+
+  return query;
+}
+
+export type listBlocklistResponse200 = {
+  data: BlocklistEntryResponse[];
+  status: 200;
+};
+
+export type listBlocklistResponseSuccess = listBlocklistResponse200 & {
+  headers: Headers;
+};
+export type listBlocklistResponse = listBlocklistResponseSuccess;
+
+export const getListBlocklistUrl = () => {
+  return `/v1/invitations/blocklist`;
+};
+
+/**
+ * @summary List Blocklist
+ */
+export const listBlocklist = async (
+  options?: Parameters<typeof customFetch>[1],
+): Promise<listBlocklistResponse> => {
+  return customFetch<listBlocklistResponse>(getListBlocklistUrl(), {
+    ...options,
+    method: 'GET',
+  });
+};
+
+export const getListBlocklistQueryKey = () => {
+  return ['v1', 'invitations', 'blocklist'] as const;
+};
+
+export const getListBlocklistQueryOptions = <
+  TData = Awaited<ReturnType<typeof listBlocklist>>,
+  TError = unknown,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<Awaited<ReturnType<typeof listBlocklist>>, TError, TData>
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = getListBlocklistQueryKey();
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof listBlocklist>>> = ({
+    signal,
+  }) => listBlocklist({ signal, ...requestOptions });
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof listBlocklist>>,
+    TError,
+    TData
+  >;
+};
+
+export type ListBlocklistQueryResult = NonNullable<
+  Awaited<ReturnType<typeof listBlocklist>>
+>;
+export type ListBlocklistQueryError = unknown;
+
+/**
+ * @summary List Blocklist
+ */
+
+export function useListBlocklist<
+  TData = Awaited<ReturnType<typeof listBlocklist>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof listBlocklist>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseQueryReturnType<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getListBlocklistQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = unref(queryOptions).queryKey as DataTag<
+    QueryKey,
+    TData,
+    TError
+  >;
+
+  return query;
+}
+
+export type blockInviterResponse204 = {
+  data: void;
+  status: 204;
+};
+
+export type blockInviterResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type blockInviterResponseSuccess = blockInviterResponse204 & {
+  headers: Headers;
+};
+export type blockInviterResponseError = blockInviterResponse422 & {
+  headers: Headers;
+};
+
+export type blockInviterResponse =
+  blockInviterResponseSuccess | blockInviterResponseError;
+
+export const getBlockInviterUrl = () => {
+  return `/v1/invitations/blocklist`;
+};
+
+/**
+ * @summary Block Inviter
+ */
+export const blockInviter = async (
+  blocklistAddRequest: BlocklistAddRequest,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<blockInviterResponse> => {
+  return customFetch<blockInviterResponse>(getBlockInviterUrl(), {
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(blocklistAddRequest),
+  });
+};
+
+export const getBlockInviterMutationOptions = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof blockInviter>>,
+    TError,
+    { data: BlocklistAddRequest },
+    TContext
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof blockInviter>>,
+  TError,
+  { data: BlocklistAddRequest },
+  TContext
+> => {
+  const mutationKey = ['blockInviter'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof blockInviter>>,
+    { data: BlocklistAddRequest }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return blockInviter(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type BlockInviterMutationResult = NonNullable<
+  Awaited<ReturnType<typeof blockInviter>>
+>;
+export type BlockInviterMutationBody = BlocklistAddRequest;
+export type BlockInviterMutationError = HTTPValidationError;
+
+/**
+ * @summary Block Inviter
+ */
+export const useBlockInviter = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof blockInviter>>,
+      TError,
+      { data: BlocklistAddRequest },
+      TContext
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseMutationReturnType<
+  Awaited<ReturnType<typeof blockInviter>>,
+  TError,
+  { data: BlocklistAddRequest },
+  TContext
+> => {
+  return useMutation(getBlockInviterMutationOptions(options), queryClient);
+};
+
+export type unblockUserResponse204 = {
+  data: void;
+  status: 204;
+};
+
+export type unblockUserResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type unblockUserResponseSuccess = unblockUserResponse204 & {
+  headers: Headers;
+};
+export type unblockUserResponseError = unblockUserResponse422 & {
+  headers: Headers;
+};
+
+export type unblockUserResponse =
+  unblockUserResponseSuccess | unblockUserResponseError;
+
+export const getUnblockUserUrl = (blockedUserId: string) => {
+  return `/v1/invitations/blocklist/${blockedUserId}`;
+};
+
+/**
+ * @summary Unblock User
+ */
+export const unblockUser = async (
+  blockedUserId: string,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<unblockUserResponse> => {
+  return customFetch<unblockUserResponse>(getUnblockUserUrl(blockedUserId), {
+    ...options,
+    method: 'DELETE',
+  });
+};
+
+export const getUnblockUserMutationOptions = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof unblockUser>>,
+    TError,
+    { blockedUserId: string },
+    TContext
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof unblockUser>>,
+  TError,
+  { blockedUserId: string },
+  TContext
+> => {
+  const mutationKey = ['unblockUser'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof unblockUser>>,
+    { blockedUserId: string }
+  > = (props) => {
+    const { blockedUserId } = props ?? {};
+
+    return unblockUser(blockedUserId, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type UnblockUserMutationResult = NonNullable<
+  Awaited<ReturnType<typeof unblockUser>>
+>;
+
+export type UnblockUserMutationError = HTTPValidationError;
+
+/**
+ * @summary Unblock User
+ */
+export const useUnblockUser = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof unblockUser>>,
+      TError,
+      { blockedUserId: string },
+      TContext
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseMutationReturnType<
+  Awaited<ReturnType<typeof unblockUser>>,
+  TError,
+  { blockedUserId: string },
+  TContext
+> => {
+  return useMutation(getUnblockUserMutationOptions(options), queryClient);
+};
+
+export type acceptInvitationResponse204 = {
+  data: void;
+  status: 204;
+};
+
+export type acceptInvitationResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type acceptInvitationResponseSuccess = acceptInvitationResponse204 & {
+  headers: Headers;
+};
+export type acceptInvitationResponseError = acceptInvitationResponse422 & {
+  headers: Headers;
+};
+
+export type acceptInvitationResponse =
+  acceptInvitationResponseSuccess | acceptInvitationResponseError;
+
+export const getAcceptInvitationUrl = (invitationId: string) => {
+  return `/v1/invitations/${invitationId}/accept`;
+};
+
+/**
+ * @summary Accept Invitation
+ */
+export const acceptInvitation = async (
+  invitationId: string,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<acceptInvitationResponse> => {
+  return customFetch<acceptInvitationResponse>(
+    getAcceptInvitationUrl(invitationId),
+    {
+      ...options,
+      method: 'POST',
+    },
+  );
+};
+
+export const getAcceptInvitationMutationOptions = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof acceptInvitation>>,
+    TError,
+    { invitationId: string },
+    TContext
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof acceptInvitation>>,
+  TError,
+  { invitationId: string },
+  TContext
+> => {
+  const mutationKey = ['acceptInvitation'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof acceptInvitation>>,
+    { invitationId: string }
+  > = (props) => {
+    const { invitationId } = props ?? {};
+
+    return acceptInvitation(invitationId, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type AcceptInvitationMutationResult = NonNullable<
+  Awaited<ReturnType<typeof acceptInvitation>>
+>;
+
+export type AcceptInvitationMutationError = HTTPValidationError;
+
+/**
+ * @summary Accept Invitation
+ */
+export const useAcceptInvitation = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof acceptInvitation>>,
+      TError,
+      { invitationId: string },
+      TContext
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseMutationReturnType<
+  Awaited<ReturnType<typeof acceptInvitation>>,
+  TError,
+  { invitationId: string },
+  TContext
+> => {
+  return useMutation(getAcceptInvitationMutationOptions(options), queryClient);
+};
+
+export type ignoreInvitationResponse204 = {
+  data: void;
+  status: 204;
+};
+
+export type ignoreInvitationResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type ignoreInvitationResponseSuccess = ignoreInvitationResponse204 & {
+  headers: Headers;
+};
+export type ignoreInvitationResponseError = ignoreInvitationResponse422 & {
+  headers: Headers;
+};
+
+export type ignoreInvitationResponse =
+  ignoreInvitationResponseSuccess | ignoreInvitationResponseError;
+
+export const getIgnoreInvitationUrl = (invitationId: string) => {
+  return `/v1/invitations/${invitationId}/ignore`;
+};
+
+/**
+ * @summary Ignore Invitation
+ */
+export const ignoreInvitation = async (
+  invitationId: string,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<ignoreInvitationResponse> => {
+  return customFetch<ignoreInvitationResponse>(
+    getIgnoreInvitationUrl(invitationId),
+    {
+      ...options,
+      method: 'POST',
+    },
+  );
+};
+
+export const getIgnoreInvitationMutationOptions = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof ignoreInvitation>>,
+    TError,
+    { invitationId: string },
+    TContext
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof ignoreInvitation>>,
+  TError,
+  { invitationId: string },
+  TContext
+> => {
+  const mutationKey = ['ignoreInvitation'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof ignoreInvitation>>,
+    { invitationId: string }
+  > = (props) => {
+    const { invitationId } = props ?? {};
+
+    return ignoreInvitation(invitationId, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type IgnoreInvitationMutationResult = NonNullable<
+  Awaited<ReturnType<typeof ignoreInvitation>>
+>;
+
+export type IgnoreInvitationMutationError = HTTPValidationError;
+
+/**
+ * @summary Ignore Invitation
+ */
+export const useIgnoreInvitation = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof ignoreInvitation>>,
+      TError,
+      { invitationId: string },
+      TContext
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseMutationReturnType<
+  Awaited<ReturnType<typeof ignoreInvitation>>,
+  TError,
+  { invitationId: string },
+  TContext
+> => {
+  return useMutation(getIgnoreInvitationMutationOptions(options), queryClient);
+};
 
 export type listPathsResponse200 = {
   data: PathResponse[];
@@ -353,6 +3062,110 @@ export const useCreatePath = <TError = HTTPValidationError, TContext = unknown>(
   return useMutation(getCreatePathMutationOptions(options), queryClient);
 };
 
+export type deletePathResponse204 = {
+  data: void;
+  status: 204;
+};
+
+export type deletePathResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type deletePathResponseSuccess = deletePathResponse204 & {
+  headers: Headers;
+};
+export type deletePathResponseError = deletePathResponse422 & {
+  headers: Headers;
+};
+
+export type deletePathResponse =
+  deletePathResponseSuccess | deletePathResponseError;
+
+export const getDeletePathUrl = (pathCode: string) => {
+  return `/v1/paths/${pathCode}`;
+};
+
+/**
+ * @summary Delete Path
+ */
+export const deletePath = async (
+  pathCode: string,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<deletePathResponse> => {
+  return customFetch<deletePathResponse>(getDeletePathUrl(pathCode), {
+    ...options,
+    method: 'DELETE',
+  });
+};
+
+export const getDeletePathMutationOptions = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof deletePath>>,
+    TError,
+    { pathCode: string },
+    TContext
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof deletePath>>,
+  TError,
+  { pathCode: string },
+  TContext
+> => {
+  const mutationKey = ['deletePath'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof deletePath>>,
+    { pathCode: string }
+  > = (props) => {
+    const { pathCode } = props ?? {};
+
+    return deletePath(pathCode, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type DeletePathMutationResult = NonNullable<
+  Awaited<ReturnType<typeof deletePath>>
+>;
+
+export type DeletePathMutationError = HTTPValidationError;
+
+/**
+ * @summary Delete Path
+ */
+export const useDeletePath = <TError = HTTPValidationError, TContext = unknown>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof deletePath>>,
+      TError,
+      { pathCode: string },
+      TContext
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseMutationReturnType<
+  Awaited<ReturnType<typeof deletePath>>,
+  TError,
+  { pathCode: string },
+  TContext
+> => {
+  return useMutation(getDeletePathMutationOptions(options), queryClient);
+};
+
 export type updatePathResponse200 = {
   data: PathResponse;
   status: 200;
@@ -458,228 +3271,6 @@ export const useUpdatePath = <TError = HTTPValidationError, TContext = unknown>(
   TContext
 > => {
   return useMutation(getUpdatePathMutationOptions(options), queryClient);
-};
-
-export type deletePathResponse204 = {
-  data: void;
-  status: 204;
-};
-
-export type deletePathResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type deletePathResponseSuccess = deletePathResponse204 & {
-  headers: Headers;
-};
-export type deletePathResponseError = deletePathResponse422 & {
-  headers: Headers;
-};
-
-export type deletePathResponse =
-  deletePathResponseSuccess | deletePathResponseError;
-
-export const getDeletePathUrl = (pathCode: string) => {
-  return `/v1/paths/${pathCode}`;
-};
-
-/**
- * @summary Delete Path
- */
-export const deletePath = async (
-  pathCode: string,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<deletePathResponse> => {
-  return customFetch<deletePathResponse>(getDeletePathUrl(pathCode), {
-    ...options,
-    method: 'DELETE',
-  });
-};
-
-export const getDeletePathMutationOptions = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof deletePath>>,
-    TError,
-    { pathCode: string },
-    TContext
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof deletePath>>,
-  TError,
-  { pathCode: string },
-  TContext
-> => {
-  const mutationKey = ['deletePath'];
-  const { mutation: mutationOptions, request: requestOptions } = options
-    ? options.mutation &&
-      'mutationKey' in options.mutation &&
-      options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey }, request: undefined };
-
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof deletePath>>,
-    { pathCode: string }
-  > = (props) => {
-    const { pathCode } = props ?? {};
-
-    return deletePath(pathCode, requestOptions);
-  };
-
-  return { mutationFn, ...mutationOptions };
-};
-
-export type DeletePathMutationResult = NonNullable<
-  Awaited<ReturnType<typeof deletePath>>
->;
-
-export type DeletePathMutationError = HTTPValidationError;
-
-/**
- * @summary Delete Path
- */
-export const useDeletePath = <TError = HTTPValidationError, TContext = unknown>(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof deletePath>>,
-      TError,
-      { pathCode: string },
-      TContext
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseMutationReturnType<
-  Awaited<ReturnType<typeof deletePath>>,
-  TError,
-  { pathCode: string },
-  TContext
-> => {
-  return useMutation(getDeletePathMutationOptions(options), queryClient);
-};
-
-export type updatePathVisibilityResponse200 = {
-  data: PathResponse;
-  status: 200;
-};
-
-export type updatePathVisibilityResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type updatePathVisibilityResponseSuccess =
-  updatePathVisibilityResponse200 & {
-    headers: Headers;
-  };
-export type updatePathVisibilityResponseError =
-  updatePathVisibilityResponse422 & {
-    headers: Headers;
-  };
-
-export type updatePathVisibilityResponse =
-  updatePathVisibilityResponseSuccess | updatePathVisibilityResponseError;
-
-export const getUpdatePathVisibilityUrl = (pathCode: string) => {
-  return `/v1/paths/${pathCode}/visibility`;
-};
-
-/**
- * @summary Update Path Visibility
- */
-export const updatePathVisibility = async (
-  pathCode: string,
-  pathVisibilityUpdateRequest: PathVisibilityUpdateRequest,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<updatePathVisibilityResponse> => {
-  return customFetch<updatePathVisibilityResponse>(
-    getUpdatePathVisibilityUrl(pathCode),
-    {
-      ...options,
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', ...options?.headers },
-      body: JSON.stringify(pathVisibilityUpdateRequest),
-    },
-  );
-};
-
-export const getUpdatePathVisibilityMutationOptions = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof updatePathVisibility>>,
-    TError,
-    { pathCode: string; data: PathVisibilityUpdateRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof updatePathVisibility>>,
-  TError,
-  { pathCode: string; data: PathVisibilityUpdateRequest },
-  TContext
-> => {
-  const mutationKey = ['updatePathVisibility'];
-  const { mutation: mutationOptions, request: requestOptions } = options
-    ? options.mutation &&
-      'mutationKey' in options.mutation &&
-      options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey }, request: undefined };
-
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof updatePathVisibility>>,
-    { pathCode: string; data: PathVisibilityUpdateRequest }
-  > = (props) => {
-    const { pathCode, data } = props ?? {};
-
-    return updatePathVisibility(pathCode, data, requestOptions);
-  };
-
-  return { mutationFn, ...mutationOptions };
-};
-
-export type UpdatePathVisibilityMutationResult = NonNullable<
-  Awaited<ReturnType<typeof updatePathVisibility>>
->;
-export type UpdatePathVisibilityMutationBody = PathVisibilityUpdateRequest;
-export type UpdatePathVisibilityMutationError = HTTPValidationError;
-
-/**
- * @summary Update Path Visibility
- */
-export const useUpdatePathVisibility = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof updatePathVisibility>>,
-      TError,
-      { pathCode: string; data: PathVisibilityUpdateRequest },
-      TContext
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseMutationReturnType<
-  Awaited<ReturnType<typeof updatePathVisibility>>,
-  TError,
-  { pathCode: string; data: PathVisibilityUpdateRequest },
-  TContext
-> => {
-  return useMutation(
-    getUpdatePathVisibilityMutationOptions(options),
-    queryClient,
-  );
 };
 
 export type listEntriesResponse200 = {
@@ -826,14 +3417,14 @@ export const createEntry = async (
   options?: Parameters<typeof customFetch>[1],
 ): Promise<createEntryResponse> => {
   const formData = new FormData();
-  formData.append(`entry_id`, bodyCreateEntry.entry_id);
-  formData.append(`day`, bodyCreateEntry.day);
-  formData.append(`content`, bodyCreateEntry.content);
   if (bodyCreateEntry.captions !== undefined) {
     bodyCreateEntry.captions.forEach((value) =>
       formData.append(`captions`, value),
     );
   }
+  formData.append(`content`, bodyCreateEntry.content);
+  formData.append(`day`, bodyCreateEntry.day);
+  formData.append(`entry_id`, bodyCreateEntry.entry_id);
   if (bodyCreateEntry.images !== undefined) {
     bodyCreateEntry.images.forEach((value) => formData.append(`images`, value));
   }
@@ -913,6 +3504,117 @@ export const useCreateEntry = <
   TContext
 > => {
   return useMutation(getCreateEntryMutationOptions(options), queryClient);
+};
+
+export type deleteEntryResponse204 = {
+  data: void;
+  status: 204;
+};
+
+export type deleteEntryResponse422 = {
+  data: HTTPValidationError;
+  status: 422;
+};
+
+export type deleteEntryResponseSuccess = deleteEntryResponse204 & {
+  headers: Headers;
+};
+export type deleteEntryResponseError = deleteEntryResponse422 & {
+  headers: Headers;
+};
+
+export type deleteEntryResponse =
+  deleteEntryResponseSuccess | deleteEntryResponseError;
+
+export const getDeleteEntryUrl = (pathCode: string, entrySlug: string) => {
+  return `/v1/paths/${pathCode}/entries/${entrySlug}`;
+};
+
+/**
+ * @summary Delete Entry
+ */
+export const deleteEntry = async (
+  pathCode: string,
+  entrySlug: string,
+  options?: Parameters<typeof customFetch>[1],
+): Promise<deleteEntryResponse> => {
+  return customFetch<deleteEntryResponse>(
+    getDeleteEntryUrl(pathCode, entrySlug),
+    {
+      ...options,
+      method: 'DELETE',
+    },
+  );
+};
+
+export const getDeleteEntryMutationOptions = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof deleteEntry>>,
+    TError,
+    { pathCode: string; entrySlug: string },
+    TContext
+  >;
+  request?: SecondParameter<typeof customFetch>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof deleteEntry>>,
+  TError,
+  { pathCode: string; entrySlug: string },
+  TContext
+> => {
+  const mutationKey = ['deleteEntry'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof deleteEntry>>,
+    { pathCode: string; entrySlug: string }
+  > = (props) => {
+    const { pathCode, entrySlug } = props ?? {};
+
+    return deleteEntry(pathCode, entrySlug, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type DeleteEntryMutationResult = NonNullable<
+  Awaited<ReturnType<typeof deleteEntry>>
+>;
+
+export type DeleteEntryMutationError = HTTPValidationError;
+
+/**
+ * @summary Delete Entry
+ */
+export const useDeleteEntry = <
+  TError = HTTPValidationError,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof deleteEntry>>,
+      TError,
+      { pathCode: string; entrySlug: string },
+      TContext
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+  queryClient?: QueryClient,
+): UseMutationReturnType<
+  Awaited<ReturnType<typeof deleteEntry>>,
+  TError,
+  { pathCode: string; entrySlug: string },
+  TContext
+> => {
+  return useMutation(getDeleteEntryMutationOptions(options), queryClient);
 };
 
 export type getEntryResponse200 = {
@@ -1080,23 +3782,23 @@ export const updateEntry = async (
   options?: Parameters<typeof customFetch>[1],
 ): Promise<updateEntryResponse> => {
   const formData = new FormData();
-  formData.append(
-    `expected_edit_id`,
-    bodyUpdateEntry.expected_edit_id.toString(),
-  );
-  formData.append(`content`, bodyUpdateEntry.content);
   if (bodyUpdateEntry.captions !== undefined) {
     bodyUpdateEntry.captions.forEach((value) =>
       formData.append(`captions`, value),
     );
   }
+  formData.append(`content`, bodyUpdateEntry.content);
+  formData.append(
+    `expected_edit_id`,
+    bodyUpdateEntry.expected_edit_id.toString(),
+  );
+  if (bodyUpdateEntry.images !== undefined) {
+    bodyUpdateEntry.images.forEach((value) => formData.append(`images`, value));
+  }
   if (bodyUpdateEntry.remove_image_ids !== undefined) {
     bodyUpdateEntry.remove_image_ids.forEach((value) =>
       formData.append(`remove_image_ids`, value),
     );
-  }
-  if (bodyUpdateEntry.images !== undefined) {
-    bodyUpdateEntry.images.forEach((value) => formData.append(`images`, value));
   }
 
   return customFetch<updateEntryResponse>(
@@ -1178,117 +3880,6 @@ export const useUpdateEntry = <
   TContext
 > => {
   return useMutation(getUpdateEntryMutationOptions(options), queryClient);
-};
-
-export type deleteEntryResponse204 = {
-  data: void;
-  status: 204;
-};
-
-export type deleteEntryResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type deleteEntryResponseSuccess = deleteEntryResponse204 & {
-  headers: Headers;
-};
-export type deleteEntryResponseError = deleteEntryResponse422 & {
-  headers: Headers;
-};
-
-export type deleteEntryResponse =
-  deleteEntryResponseSuccess | deleteEntryResponseError;
-
-export const getDeleteEntryUrl = (pathCode: string, entrySlug: string) => {
-  return `/v1/paths/${pathCode}/entries/${entrySlug}`;
-};
-
-/**
- * @summary Delete Entry
- */
-export const deleteEntry = async (
-  pathCode: string,
-  entrySlug: string,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<deleteEntryResponse> => {
-  return customFetch<deleteEntryResponse>(
-    getDeleteEntryUrl(pathCode, entrySlug),
-    {
-      ...options,
-      method: 'DELETE',
-    },
-  );
-};
-
-export const getDeleteEntryMutationOptions = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof deleteEntry>>,
-    TError,
-    { pathCode: string; entrySlug: string },
-    TContext
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof deleteEntry>>,
-  TError,
-  { pathCode: string; entrySlug: string },
-  TContext
-> => {
-  const mutationKey = ['deleteEntry'];
-  const { mutation: mutationOptions, request: requestOptions } = options
-    ? options.mutation &&
-      'mutationKey' in options.mutation &&
-      options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey }, request: undefined };
-
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof deleteEntry>>,
-    { pathCode: string; entrySlug: string }
-  > = (props) => {
-    const { pathCode, entrySlug } = props ?? {};
-
-    return deleteEntry(pathCode, entrySlug, requestOptions);
-  };
-
-  return { mutationFn, ...mutationOptions };
-};
-
-export type DeleteEntryMutationResult = NonNullable<
-  Awaited<ReturnType<typeof deleteEntry>>
->;
-
-export type DeleteEntryMutationError = HTTPValidationError;
-
-/**
- * @summary Delete Entry
- */
-export const useDeleteEntry = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof deleteEntry>>,
-      TError,
-      { pathCode: string; entrySlug: string },
-      TContext
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseMutationReturnType<
-  Awaited<ReturnType<typeof deleteEntry>>,
-  TError,
-  { pathCode: string; entrySlug: string },
-  TContext
-> => {
-  return useMutation(getDeleteEntryMutationOptions(options), queryClient);
 };
 
 export type listEntryImagesResponse200 = {
@@ -1795,808 +4386,69 @@ export const useDeleteSubscription = <
   );
 };
 
-export type adminLoginResponse200 = {
-  data: AdminLoginResponse;
+export type updatePathVisibilityResponse200 = {
+  data: PathResponse;
   status: 200;
 };
 
-export type adminLoginResponse422 = {
+export type updatePathVisibilityResponse422 = {
   data: HTTPValidationError;
   status: 422;
 };
 
-export type adminLoginResponseSuccess = adminLoginResponse200 & {
-  headers: Headers;
-};
-export type adminLoginResponseError = adminLoginResponse422 & {
-  headers: Headers;
-};
-
-export type adminLoginResponse =
-  adminLoginResponseSuccess | adminLoginResponseError;
-
-export const getAdminLoginUrl = () => {
-  return `/v1/admin/login`;
-};
-
-/**
- * @summary Admin Login
- */
-export const adminLogin = async (
-  adminLoginRequest: AdminLoginRequest,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<adminLoginResponse> => {
-  return customFetch<adminLoginResponse>(getAdminLoginUrl(), {
-    ...options,
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
-    body: JSON.stringify(adminLoginRequest),
-  });
-};
-
-export const getAdminLoginMutationOptions = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof adminLogin>>,
-    TError,
-    { data: AdminLoginRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof adminLogin>>,
-  TError,
-  { data: AdminLoginRequest },
-  TContext
-> => {
-  const mutationKey = ['adminLogin'];
-  const { mutation: mutationOptions, request: requestOptions } = options
-    ? options.mutation &&
-      'mutationKey' in options.mutation &&
-      options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey }, request: undefined };
-
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof adminLogin>>,
-    { data: AdminLoginRequest }
-  > = (props) => {
-    const { data } = props ?? {};
-
-    return adminLogin(data, requestOptions);
-  };
-
-  return { mutationFn, ...mutationOptions };
-};
-
-export type AdminLoginMutationResult = NonNullable<
-  Awaited<ReturnType<typeof adminLogin>>
->;
-export type AdminLoginMutationBody = AdminLoginRequest;
-export type AdminLoginMutationError = HTTPValidationError;
-
-/**
- * @summary Admin Login
- */
-export const useAdminLogin = <TError = HTTPValidationError, TContext = unknown>(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof adminLogin>>,
-      TError,
-      { data: AdminLoginRequest },
-      TContext
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseMutationReturnType<
-  Awaited<ReturnType<typeof adminLogin>>,
-  TError,
-  { data: AdminLoginRequest },
-  TContext
-> => {
-  return useMutation(getAdminLoginMutationOptions(options), queryClient);
-};
-
-export type setPathCreationApprovalResponse200 = {
-  data: PathCreationApprovalResponse;
-  status: 200;
-};
-
-export type setPathCreationApprovalResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type setPathCreationApprovalResponseSuccess =
-  setPathCreationApprovalResponse200 & {
+export type updatePathVisibilityResponseSuccess =
+  updatePathVisibilityResponse200 & {
     headers: Headers;
   };
-export type setPathCreationApprovalResponseError =
-  setPathCreationApprovalResponse422 & {
+export type updatePathVisibilityResponseError =
+  updatePathVisibilityResponse422 & {
     headers: Headers;
   };
 
-export type setPathCreationApprovalResponse =
-  setPathCreationApprovalResponseSuccess | setPathCreationApprovalResponseError;
+export type updatePathVisibilityResponse =
+  updatePathVisibilityResponseSuccess | updatePathVisibilityResponseError;
 
-export const getSetPathCreationApprovalUrl = (userId: string) => {
-  return `/v1/admin/users/${userId}/path-creation-approval`;
+export const getUpdatePathVisibilityUrl = (pathCode: string) => {
+  return `/v1/paths/${pathCode}/visibility`;
 };
 
 /**
- * @summary Set Path Creation Approval
+ * @summary Update Path Visibility
  */
-export const setPathCreationApproval = async (
-  userId: string,
-  pathCreationApprovalRequest: PathCreationApprovalRequest,
+export const updatePathVisibility = async (
+  pathCode: string,
+  pathVisibilityUpdateRequest: PathVisibilityUpdateRequest,
   options?: Parameters<typeof customFetch>[1],
-): Promise<setPathCreationApprovalResponse> => {
-  return customFetch<setPathCreationApprovalResponse>(
-    getSetPathCreationApprovalUrl(userId),
-    {
-      ...options,
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', ...options?.headers },
-      body: JSON.stringify(pathCreationApprovalRequest),
-    },
-  );
-};
-
-export const getSetPathCreationApprovalMutationOptions = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof setPathCreationApproval>>,
-    TError,
-    { userId: string; data: PathCreationApprovalRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof setPathCreationApproval>>,
-  TError,
-  { userId: string; data: PathCreationApprovalRequest },
-  TContext
-> => {
-  const mutationKey = ['setPathCreationApproval'];
-  const { mutation: mutationOptions, request: requestOptions } = options
-    ? options.mutation &&
-      'mutationKey' in options.mutation &&
-      options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey }, request: undefined };
-
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof setPathCreationApproval>>,
-    { userId: string; data: PathCreationApprovalRequest }
-  > = (props) => {
-    const { userId, data } = props ?? {};
-
-    return setPathCreationApproval(userId, data, requestOptions);
-  };
-
-  return { mutationFn, ...mutationOptions };
-};
-
-export type SetPathCreationApprovalMutationResult = NonNullable<
-  Awaited<ReturnType<typeof setPathCreationApproval>>
->;
-export type SetPathCreationApprovalMutationBody = PathCreationApprovalRequest;
-export type SetPathCreationApprovalMutationError = HTTPValidationError;
-
-/**
- * @summary Set Path Creation Approval
- */
-export const useSetPathCreationApproval = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof setPathCreationApproval>>,
-      TError,
-      { userId: string; data: PathCreationApprovalRequest },
-      TContext
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseMutationReturnType<
-  Awaited<ReturnType<typeof setPathCreationApproval>>,
-  TError,
-  { userId: string; data: PathCreationApprovalRequest },
-  TContext
-> => {
-  return useMutation(
-    getSetPathCreationApprovalMutationOptions(options),
-    queryClient,
-  );
-};
-
-export type getProfileResponse200 = {
-  data: UserProfileResponse;
-  status: 200;
-};
-
-export type getProfileResponseSuccess = getProfileResponse200 & {
-  headers: Headers;
-};
-export type getProfileResponse = getProfileResponseSuccess;
-
-export const getGetProfileUrl = () => {
-  return `/v1/account/profile`;
-};
-
-/**
- * @summary Get Profile
- */
-export const getProfile = async (
-  options?: Parameters<typeof customFetch>[1],
-): Promise<getProfileResponse> => {
-  return customFetch<getProfileResponse>(getGetProfileUrl(), {
-    ...options,
-    method: 'GET',
-  });
-};
-
-export const getGetProfileQueryKey = () => {
-  return ['v1', 'account', 'profile'] as const;
-};
-
-export const getGetProfileQueryOptions = <
-  TData = Awaited<ReturnType<typeof getProfile>>,
-  TError = unknown,
->(options?: {
-  query?: Partial<
-    UseQueryOptions<Awaited<ReturnType<typeof getProfile>>, TError, TData>
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
-
-  const queryKey = getGetProfileQueryKey();
-
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof getProfile>>> = ({
-    signal,
-  }) => getProfile({ signal, ...requestOptions });
-
-  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof getProfile>>,
-    TError,
-    TData
-  >;
-};
-
-export type GetProfileQueryResult = NonNullable<
-  Awaited<ReturnType<typeof getProfile>>
->;
-export type GetProfileQueryError = unknown;
-
-/**
- * @summary Get Profile
- */
-
-export function useGetProfile<
-  TData = Awaited<ReturnType<typeof getProfile>>,
-  TError = unknown,
->(
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof getProfile>>, TError, TData>
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseQueryReturnType<TData, TError> & {
-  queryKey: DataTag<QueryKey, TData, TError>;
-} {
-  const queryOptions = getGetProfileQueryOptions(options);
-
-  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
-    TData,
-    TError
-  > & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = unref(queryOptions).queryKey as DataTag<
-    QueryKey,
-    TData,
-    TError
-  >;
-
-  return query;
-}
-
-export type updateDisplayNameResponse200 = {
-  data: UserProfileResponse;
-  status: 200;
-};
-
-export type updateDisplayNameResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type updateDisplayNameResponseSuccess = updateDisplayNameResponse200 & {
-  headers: Headers;
-};
-export type updateDisplayNameResponseError = updateDisplayNameResponse422 & {
-  headers: Headers;
-};
-
-export type updateDisplayNameResponse =
-  updateDisplayNameResponseSuccess | updateDisplayNameResponseError;
-
-export const getUpdateDisplayNameUrl = () => {
-  return `/v1/account/display-name`;
-};
-
-/**
- * @summary Update Display Name
- */
-export const updateDisplayName = async (
-  userDisplayNameUpdateRequest: UserDisplayNameUpdateRequest,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<updateDisplayNameResponse> => {
-  return customFetch<updateDisplayNameResponse>(getUpdateDisplayNameUrl(), {
-    ...options,
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
-    body: JSON.stringify(userDisplayNameUpdateRequest),
-  });
-};
-
-export const getUpdateDisplayNameMutationOptions = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof updateDisplayName>>,
-    TError,
-    { data: UserDisplayNameUpdateRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof updateDisplayName>>,
-  TError,
-  { data: UserDisplayNameUpdateRequest },
-  TContext
-> => {
-  const mutationKey = ['updateDisplayName'];
-  const { mutation: mutationOptions, request: requestOptions } = options
-    ? options.mutation &&
-      'mutationKey' in options.mutation &&
-      options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey }, request: undefined };
-
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof updateDisplayName>>,
-    { data: UserDisplayNameUpdateRequest }
-  > = (props) => {
-    const { data } = props ?? {};
-
-    return updateDisplayName(data, requestOptions);
-  };
-
-  return { mutationFn, ...mutationOptions };
-};
-
-export type UpdateDisplayNameMutationResult = NonNullable<
-  Awaited<ReturnType<typeof updateDisplayName>>
->;
-export type UpdateDisplayNameMutationBody = UserDisplayNameUpdateRequest;
-export type UpdateDisplayNameMutationError = HTTPValidationError;
-
-/**
- * @summary Update Display Name
- */
-export const useUpdateDisplayName = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof updateDisplayName>>,
-      TError,
-      { data: UserDisplayNameUpdateRequest },
-      TContext
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseMutationReturnType<
-  Awaited<ReturnType<typeof updateDisplayName>>,
-  TError,
-  { data: UserDisplayNameUpdateRequest },
-  TContext
-> => {
-  return useMutation(getUpdateDisplayNameMutationOptions(options), queryClient);
-};
-
-export type updateSettingsResponse200 = {
-  data: UserProfileResponse;
-  status: 200;
-};
-
-export type updateSettingsResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type updateSettingsResponseSuccess = updateSettingsResponse200 & {
-  headers: Headers;
-};
-export type updateSettingsResponseError = updateSettingsResponse422 & {
-  headers: Headers;
-};
-
-export type updateSettingsResponse =
-  updateSettingsResponseSuccess | updateSettingsResponseError;
-
-export const getUpdateSettingsUrl = () => {
-  return `/v1/account/settings`;
-};
-
-/**
- * @summary Update Settings
- */
-export const updateSettings = async (
-  userSettingsUpdateRequest: UserSettingsUpdateRequest,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<updateSettingsResponse> => {
-  return customFetch<updateSettingsResponse>(getUpdateSettingsUrl(), {
-    ...options,
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
-    body: JSON.stringify(userSettingsUpdateRequest),
-  });
-};
-
-export const getUpdateSettingsMutationOptions = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof updateSettings>>,
-    TError,
-    { data: UserSettingsUpdateRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof updateSettings>>,
-  TError,
-  { data: UserSettingsUpdateRequest },
-  TContext
-> => {
-  const mutationKey = ['updateSettings'];
-  const { mutation: mutationOptions, request: requestOptions } = options
-    ? options.mutation &&
-      'mutationKey' in options.mutation &&
-      options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey }, request: undefined };
-
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof updateSettings>>,
-    { data: UserSettingsUpdateRequest }
-  > = (props) => {
-    const { data } = props ?? {};
-
-    return updateSettings(data, requestOptions);
-  };
-
-  return { mutationFn, ...mutationOptions };
-};
-
-export type UpdateSettingsMutationResult = NonNullable<
-  Awaited<ReturnType<typeof updateSettings>>
->;
-export type UpdateSettingsMutationBody = UserSettingsUpdateRequest;
-export type UpdateSettingsMutationError = HTTPValidationError;
-
-/**
- * @summary Update Settings
- */
-export const useUpdateSettings = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof updateSettings>>,
-      TError,
-      { data: UserSettingsUpdateRequest },
-      TContext
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseMutationReturnType<
-  Awaited<ReturnType<typeof updateSettings>>,
-  TError,
-  { data: UserSettingsUpdateRequest },
-  TContext
-> => {
-  return useMutation(getUpdateSettingsMutationOptions(options), queryClient);
-};
-
-export type createDeletionRequestResponse200 = {
-  data: DeletionRequestResponse;
-  status: 200;
-};
-
-export type createDeletionRequestResponseSuccess =
-  createDeletionRequestResponse200 & {
-    headers: Headers;
-  };
-export type createDeletionRequestResponse =
-  createDeletionRequestResponseSuccess;
-
-export const getCreateDeletionRequestUrl = () => {
-  return `/v1/account/deletion-requests`;
-};
-
-/**
- * @summary Create Deletion Request
- */
-export const createDeletionRequest = async (
-  options?: Parameters<typeof customFetch>[1],
-): Promise<createDeletionRequestResponse> => {
-  return customFetch<createDeletionRequestResponse>(
-    getCreateDeletionRequestUrl(),
-    {
-      ...options,
-      method: 'POST',
-    },
-  );
-};
-
-export const getCreateDeletionRequestMutationOptions = <
-  TError = unknown,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof createDeletionRequest>>,
-    TError,
-    void,
-    TContext
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof createDeletionRequest>>,
-  TError,
-  void,
-  TContext
-> => {
-  const mutationKey = ['createDeletionRequest'];
-  const { mutation: mutationOptions, request: requestOptions } = options
-    ? options.mutation &&
-      'mutationKey' in options.mutation &&
-      options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey }, request: undefined };
-
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof createDeletionRequest>>,
-    void
-  > = () => {
-    return createDeletionRequest(requestOptions);
-  };
-
-  return { mutationFn, ...mutationOptions };
-};
-
-export type CreateDeletionRequestMutationResult = NonNullable<
-  Awaited<ReturnType<typeof createDeletionRequest>>
->;
-
-export type CreateDeletionRequestMutationError = unknown;
-
-/**
- * @summary Create Deletion Request
- */
-export const useCreateDeletionRequest = <TError = unknown, TContext = unknown>(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof createDeletionRequest>>,
-      TError,
-      void,
-      TContext
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseMutationReturnType<
-  Awaited<ReturnType<typeof createDeletionRequest>>,
-  TError,
-  void,
-  TContext
-> => {
-  return useMutation(
-    getCreateDeletionRequestMutationOptions(options),
-    queryClient,
-  );
-};
-
-export type getLatestDeletionRequestResponse200 = {
-  data: DeletionRequestResponse;
-  status: 200;
-};
-
-export type getLatestDeletionRequestResponseSuccess =
-  getLatestDeletionRequestResponse200 & {
-    headers: Headers;
-  };
-export type getLatestDeletionRequestResponse =
-  getLatestDeletionRequestResponseSuccess;
-
-export const getGetLatestDeletionRequestUrl = () => {
-  return `/v1/account/deletion-requests/latest`;
-};
-
-/**
- * @summary Latest Deletion Request
- */
-export const getLatestDeletionRequest = async (
-  options?: Parameters<typeof customFetch>[1],
-): Promise<getLatestDeletionRequestResponse> => {
-  return customFetch<getLatestDeletionRequestResponse>(
-    getGetLatestDeletionRequestUrl(),
-    {
-      ...options,
-      method: 'GET',
-    },
-  );
-};
-
-export const getGetLatestDeletionRequestQueryKey = () => {
-  return ['v1', 'account', 'deletion-requests', 'latest'] as const;
-};
-
-export const getGetLatestDeletionRequestQueryOptions = <
-  TData = Awaited<ReturnType<typeof getLatestDeletionRequest>>,
-  TError = unknown,
->(options?: {
-  query?: Partial<
-    UseQueryOptions<
-      Awaited<ReturnType<typeof getLatestDeletionRequest>>,
-      TError,
-      TData
-    >
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
-
-  const queryKey = getGetLatestDeletionRequestQueryKey();
-
-  const queryFn: QueryFunction<
-    Awaited<ReturnType<typeof getLatestDeletionRequest>>
-  > = ({ signal }) => getLatestDeletionRequest({ signal, ...requestOptions });
-
-  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof getLatestDeletionRequest>>,
-    TError,
-    TData
-  >;
-};
-
-export type GetLatestDeletionRequestQueryResult = NonNullable<
-  Awaited<ReturnType<typeof getLatestDeletionRequest>>
->;
-export type GetLatestDeletionRequestQueryError = unknown;
-
-/**
- * @summary Latest Deletion Request
- */
-
-export function useGetLatestDeletionRequest<
-  TData = Awaited<ReturnType<typeof getLatestDeletionRequest>>,
-  TError = unknown,
->(
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof getLatestDeletionRequest>>,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseQueryReturnType<TData, TError> & {
-  queryKey: DataTag<QueryKey, TData, TError>;
-} {
-  const queryOptions = getGetLatestDeletionRequestQueryOptions(options);
-
-  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
-    TData,
-    TError
-  > & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = unref(queryOptions).queryKey as DataTag<
-    QueryKey,
-    TData,
-    TError
-  >;
-
-  return query;
-}
-
-export type updateImageCaptionResponse200 = {
-  data: ImageCaptionUpdateResponse;
-  status: 200;
-};
-
-export type updateImageCaptionResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type updateImageCaptionResponseSuccess =
-  updateImageCaptionResponse200 & {
-    headers: Headers;
-  };
-export type updateImageCaptionResponseError = updateImageCaptionResponse422 & {
-  headers: Headers;
-};
-
-export type updateImageCaptionResponse =
-  updateImageCaptionResponseSuccess | updateImageCaptionResponseError;
-
-export const getUpdateImageCaptionUrl = (imageId: string) => {
-  return `/v1/images/${imageId}`;
-};
-
-/**
- * @summary Update Image Caption
- */
-export const updateImageCaption = async (
-  imageId: string,
-  imageCaptionUpdateRequest: ImageCaptionUpdateRequest,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<updateImageCaptionResponse> => {
-  return customFetch<updateImageCaptionResponse>(
-    getUpdateImageCaptionUrl(imageId),
+): Promise<updatePathVisibilityResponse> => {
+  return customFetch<updatePathVisibilityResponse>(
+    getUpdatePathVisibilityUrl(pathCode),
     {
       ...options,
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json', ...options?.headers },
-      body: JSON.stringify(imageCaptionUpdateRequest),
+      body: JSON.stringify(pathVisibilityUpdateRequest),
     },
   );
 };
 
-export const getUpdateImageCaptionMutationOptions = <
+export const getUpdatePathVisibilityMutationOptions = <
   TError = HTTPValidationError,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof updateImageCaption>>,
+    Awaited<ReturnType<typeof updatePathVisibility>>,
     TError,
-    { imageId: string; data: ImageCaptionUpdateRequest },
+    { pathCode: string; data: PathVisibilityUpdateRequest },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationOptions<
-  Awaited<ReturnType<typeof updateImageCaption>>,
+  Awaited<ReturnType<typeof updatePathVisibility>>,
   TError,
-  { imageId: string; data: ImageCaptionUpdateRequest },
+  { pathCode: string; data: PathVisibilityUpdateRequest },
   TContext
 > => {
-  const mutationKey = ['updateImageCaption'];
+  const mutationKey = ['updatePathVisibility'];
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -2606,1753 +4458,48 @@ export const getUpdateImageCaptionMutationOptions = <
     : { mutation: { mutationKey }, request: undefined };
 
   const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof updateImageCaption>>,
-    { imageId: string; data: ImageCaptionUpdateRequest }
+    Awaited<ReturnType<typeof updatePathVisibility>>,
+    { pathCode: string; data: PathVisibilityUpdateRequest }
   > = (props) => {
-    const { imageId, data } = props ?? {};
+    const { pathCode, data } = props ?? {};
 
-    return updateImageCaption(imageId, data, requestOptions);
+    return updatePathVisibility(pathCode, data, requestOptions);
   };
 
   return { mutationFn, ...mutationOptions };
 };
 
-export type UpdateImageCaptionMutationResult = NonNullable<
-  Awaited<ReturnType<typeof updateImageCaption>>
+export type UpdatePathVisibilityMutationResult = NonNullable<
+  Awaited<ReturnType<typeof updatePathVisibility>>
 >;
-export type UpdateImageCaptionMutationBody = ImageCaptionUpdateRequest;
-export type UpdateImageCaptionMutationError = HTTPValidationError;
+export type UpdatePathVisibilityMutationBody = PathVisibilityUpdateRequest;
+export type UpdatePathVisibilityMutationError = HTTPValidationError;
 
 /**
- * @summary Update Image Caption
+ * @summary Update Path Visibility
  */
-export const useUpdateImageCaption = <
+export const useUpdatePathVisibility = <
   TError = HTTPValidationError,
   TContext = unknown,
 >(
   options?: {
     mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof updateImageCaption>>,
+      Awaited<ReturnType<typeof updatePathVisibility>>,
       TError,
-      { imageId: string; data: ImageCaptionUpdateRequest },
+      { pathCode: string; data: PathVisibilityUpdateRequest },
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
   },
   queryClient?: QueryClient,
 ): UseMutationReturnType<
-  Awaited<ReturnType<typeof updateImageCaption>>,
+  Awaited<ReturnType<typeof updatePathVisibility>>,
   TError,
-  { imageId: string; data: ImageCaptionUpdateRequest },
+  { pathCode: string; data: PathVisibilityUpdateRequest },
   TContext
 > => {
   return useMutation(
-    getUpdateImageCaptionMutationOptions(options),
+    getUpdatePathVisibilityMutationOptions(options),
     queryClient,
   );
 };
-
-export type getImageDownloadUrlResponse200 = {
-  data: ImageDownloadResponse;
-  status: 200;
-};
-
-export type getImageDownloadUrlResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type getImageDownloadUrlResponseSuccess =
-  getImageDownloadUrlResponse200 & {
-    headers: Headers;
-  };
-export type getImageDownloadUrlResponseError =
-  getImageDownloadUrlResponse422 & {
-    headers: Headers;
-  };
-
-export type getImageDownloadUrlResponse =
-  getImageDownloadUrlResponseSuccess | getImageDownloadUrlResponseError;
-
-export const getGetImageDownloadUrlUrl = (imageId: string) => {
-  return `/v1/images/${imageId}/download-url`;
-};
-
-/**
- * @summary Get Image Download Url
- */
-export const getImageDownloadUrl = async (
-  imageId: string,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<getImageDownloadUrlResponse> => {
-  return customFetch<getImageDownloadUrlResponse>(
-    getGetImageDownloadUrlUrl(imageId),
-    {
-      ...options,
-      method: 'GET',
-    },
-  );
-};
-
-export const getGetImageDownloadUrlQueryKey = (
-  imageId: MaybeRefOrGetter<string>,
-) => {
-  return ['v1', 'images', imageId, 'download-url'] as const;
-};
-
-export const getGetImageDownloadUrlQueryOptions = <
-  TData = Awaited<ReturnType<typeof getImageDownloadUrl>>,
-  TError = HTTPValidationError,
->(
-  imageId: MaybeRefOrGetter<string>,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof getImageDownloadUrl>>,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
-
-  const queryKey = getGetImageDownloadUrlQueryKey(imageId);
-
-  const queryFn: QueryFunction<
-    Awaited<ReturnType<typeof getImageDownloadUrl>>
-  > = ({ signal }) =>
-    getImageDownloadUrl(toValue(imageId), { signal, ...requestOptions });
-
-  return {
-    queryKey,
-    queryFn,
-    enabled: computed(
-      () => toValue(imageId) !== null && toValue(imageId) !== undefined,
-    ),
-    ...queryOptions,
-  } as UseQueryOptions<
-    Awaited<ReturnType<typeof getImageDownloadUrl>>,
-    TError,
-    TData
-  >;
-};
-
-export type GetImageDownloadUrlQueryResult = NonNullable<
-  Awaited<ReturnType<typeof getImageDownloadUrl>>
->;
-export type GetImageDownloadUrlQueryError = HTTPValidationError;
-
-/**
- * @summary Get Image Download Url
- */
-
-export function useGetImageDownloadUrl<
-  TData = Awaited<ReturnType<typeof getImageDownloadUrl>>,
-  TError = HTTPValidationError,
->(
-  imageId: MaybeRefOrGetter<string>,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof getImageDownloadUrl>>,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseQueryReturnType<TData, TError> & {
-  queryKey: DataTag<QueryKey, TData, TError>;
-} {
-  const queryOptions = getGetImageDownloadUrlQueryOptions(imageId, options);
-
-  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
-    TData,
-    TError
-  > & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = unref(queryOptions).queryKey as DataTag<
-    QueryKey,
-    TData,
-    TError
-  >;
-
-  return query;
-}
-
-export type createExportResponse202 = {
-  data: ExportJobResponse;
-  status: 202;
-};
-
-export type createExportResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type createExportResponseSuccess = createExportResponse202 & {
-  headers: Headers;
-};
-export type createExportResponseError = createExportResponse422 & {
-  headers: Headers;
-};
-
-export type createExportResponse =
-  createExportResponseSuccess | createExportResponseError;
-
-export const getCreateExportUrl = () => {
-  return `/v1/exports`;
-};
-
-/**
- * @summary Create Export
- */
-export const createExport = async (
-  exportCreateRequest: ExportCreateRequest,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<createExportResponse> => {
-  return customFetch<createExportResponse>(getCreateExportUrl(), {
-    ...options,
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
-    body: JSON.stringify(exportCreateRequest),
-  });
-};
-
-export const getCreateExportMutationOptions = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof createExport>>,
-    TError,
-    { data: ExportCreateRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof createExport>>,
-  TError,
-  { data: ExportCreateRequest },
-  TContext
-> => {
-  const mutationKey = ['createExport'];
-  const { mutation: mutationOptions, request: requestOptions } = options
-    ? options.mutation &&
-      'mutationKey' in options.mutation &&
-      options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey }, request: undefined };
-
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof createExport>>,
-    { data: ExportCreateRequest }
-  > = (props) => {
-    const { data } = props ?? {};
-
-    return createExport(data, requestOptions);
-  };
-
-  return { mutationFn, ...mutationOptions };
-};
-
-export type CreateExportMutationResult = NonNullable<
-  Awaited<ReturnType<typeof createExport>>
->;
-export type CreateExportMutationBody = ExportCreateRequest;
-export type CreateExportMutationError = HTTPValidationError;
-
-/**
- * @summary Create Export
- */
-export const useCreateExport = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof createExport>>,
-      TError,
-      { data: ExportCreateRequest },
-      TContext
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseMutationReturnType<
-  Awaited<ReturnType<typeof createExport>>,
-  TError,
-  { data: ExportCreateRequest },
-  TContext
-> => {
-  return useMutation(getCreateExportMutationOptions(options), queryClient);
-};
-
-export type getExportResponse200 = {
-  data: ExportJobResponse;
-  status: 200;
-};
-
-export type getExportResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type getExportResponseSuccess = getExportResponse200 & {
-  headers: Headers;
-};
-export type getExportResponseError = getExportResponse422 & {
-  headers: Headers;
-};
-
-export type getExportResponse =
-  getExportResponseSuccess | getExportResponseError;
-
-export const getGetExportUrl = (exportId: string) => {
-  return `/v1/exports/${exportId}`;
-};
-
-/**
- * @summary Get Export
- */
-export const getExport = async (
-  exportId: string,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<getExportResponse> => {
-  return customFetch<getExportResponse>(getGetExportUrl(exportId), {
-    ...options,
-    method: 'GET',
-  });
-};
-
-export const getGetExportQueryKey = (exportId: MaybeRefOrGetter<string>) => {
-  return ['v1', 'exports', exportId] as const;
-};
-
-export const getGetExportQueryOptions = <
-  TData = Awaited<ReturnType<typeof getExport>>,
-  TError = HTTPValidationError,
->(
-  exportId: MaybeRefOrGetter<string>,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof getExport>>, TError, TData>
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
-
-  const queryKey = getGetExportQueryKey(exportId);
-
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof getExport>>> = ({
-    signal,
-  }) => getExport(toValue(exportId), { signal, ...requestOptions });
-
-  return {
-    queryKey,
-    queryFn,
-    enabled: computed(
-      () => toValue(exportId) !== null && toValue(exportId) !== undefined,
-    ),
-    ...queryOptions,
-  } as UseQueryOptions<Awaited<ReturnType<typeof getExport>>, TError, TData>;
-};
-
-export type GetExportQueryResult = NonNullable<
-  Awaited<ReturnType<typeof getExport>>
->;
-export type GetExportQueryError = HTTPValidationError;
-
-/**
- * @summary Get Export
- */
-
-export function useGetExport<
-  TData = Awaited<ReturnType<typeof getExport>>,
-  TError = HTTPValidationError,
->(
-  exportId: MaybeRefOrGetter<string>,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof getExport>>, TError, TData>
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseQueryReturnType<TData, TError> & {
-  queryKey: DataTag<QueryKey, TData, TError>;
-} {
-  const queryOptions = getGetExportQueryOptions(exportId, options);
-
-  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
-    TData,
-    TError
-  > & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = unref(queryOptions).queryKey as DataTag<
-    QueryKey,
-    TData,
-    TError
-  >;
-
-  return query;
-}
-
-export type downloadExportJsonResponse200 = {
-  data: DownloadURLResponse;
-  status: 200;
-};
-
-export type downloadExportJsonResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type downloadExportJsonResponseSuccess =
-  downloadExportJsonResponse200 & {
-    headers: Headers;
-  };
-export type downloadExportJsonResponseError = downloadExportJsonResponse422 & {
-  headers: Headers;
-};
-
-export type downloadExportJsonResponse =
-  downloadExportJsonResponseSuccess | downloadExportJsonResponseError;
-
-export const getDownloadExportJsonUrl = (exportId: string) => {
-  return `/v1/exports/${exportId}/download/json`;
-};
-
-/**
- * @summary Download Json
- */
-export const downloadExportJson = async (
-  exportId: string,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<downloadExportJsonResponse> => {
-  return customFetch<downloadExportJsonResponse>(
-    getDownloadExportJsonUrl(exportId),
-    {
-      ...options,
-      method: 'GET',
-    },
-  );
-};
-
-export const getDownloadExportJsonQueryKey = (
-  exportId: MaybeRefOrGetter<string>,
-) => {
-  return ['v1', 'exports', exportId, 'download', 'json'] as const;
-};
-
-export const getDownloadExportJsonQueryOptions = <
-  TData = Awaited<ReturnType<typeof downloadExportJson>>,
-  TError = HTTPValidationError,
->(
-  exportId: MaybeRefOrGetter<string>,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof downloadExportJson>>,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
-
-  const queryKey = getDownloadExportJsonQueryKey(exportId);
-
-  const queryFn: QueryFunction<
-    Awaited<ReturnType<typeof downloadExportJson>>
-  > = ({ signal }) =>
-    downloadExportJson(toValue(exportId), { signal, ...requestOptions });
-
-  return {
-    queryKey,
-    queryFn,
-    enabled: computed(
-      () => toValue(exportId) !== null && toValue(exportId) !== undefined,
-    ),
-    ...queryOptions,
-  } as UseQueryOptions<
-    Awaited<ReturnType<typeof downloadExportJson>>,
-    TError,
-    TData
-  >;
-};
-
-export type DownloadExportJsonQueryResult = NonNullable<
-  Awaited<ReturnType<typeof downloadExportJson>>
->;
-export type DownloadExportJsonQueryError = HTTPValidationError;
-
-/**
- * @summary Download Json
- */
-
-export function useDownloadExportJson<
-  TData = Awaited<ReturnType<typeof downloadExportJson>>,
-  TError = HTTPValidationError,
->(
-  exportId: MaybeRefOrGetter<string>,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof downloadExportJson>>,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseQueryReturnType<TData, TError> & {
-  queryKey: DataTag<QueryKey, TData, TError>;
-} {
-  const queryOptions = getDownloadExportJsonQueryOptions(exportId, options);
-
-  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
-    TData,
-    TError
-  > & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = unref(queryOptions).queryKey as DataTag<
-    QueryKey,
-    TData,
-    TError
-  >;
-
-  return query;
-}
-
-export type downloadExportImagesResponse200 = {
-  data: DownloadURLResponse;
-  status: 200;
-};
-
-export type downloadExportImagesResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type downloadExportImagesResponseSuccess =
-  downloadExportImagesResponse200 & {
-    headers: Headers;
-  };
-export type downloadExportImagesResponseError =
-  downloadExportImagesResponse422 & {
-    headers: Headers;
-  };
-
-export type downloadExportImagesResponse =
-  downloadExportImagesResponseSuccess | downloadExportImagesResponseError;
-
-export const getDownloadExportImagesUrl = (exportId: string) => {
-  return `/v1/exports/${exportId}/download/images`;
-};
-
-/**
- * @summary Download Images
- */
-export const downloadExportImages = async (
-  exportId: string,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<downloadExportImagesResponse> => {
-  return customFetch<downloadExportImagesResponse>(
-    getDownloadExportImagesUrl(exportId),
-    {
-      ...options,
-      method: 'GET',
-    },
-  );
-};
-
-export const getDownloadExportImagesQueryKey = (
-  exportId: MaybeRefOrGetter<string>,
-) => {
-  return ['v1', 'exports', exportId, 'download', 'images'] as const;
-};
-
-export const getDownloadExportImagesQueryOptions = <
-  TData = Awaited<ReturnType<typeof downloadExportImages>>,
-  TError = HTTPValidationError,
->(
-  exportId: MaybeRefOrGetter<string>,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof downloadExportImages>>,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
-
-  const queryKey = getDownloadExportImagesQueryKey(exportId);
-
-  const queryFn: QueryFunction<
-    Awaited<ReturnType<typeof downloadExportImages>>
-  > = ({ signal }) =>
-    downloadExportImages(toValue(exportId), { signal, ...requestOptions });
-
-  return {
-    queryKey,
-    queryFn,
-    enabled: computed(
-      () => toValue(exportId) !== null && toValue(exportId) !== undefined,
-    ),
-    ...queryOptions,
-  } as UseQueryOptions<
-    Awaited<ReturnType<typeof downloadExportImages>>,
-    TError,
-    TData
-  >;
-};
-
-export type DownloadExportImagesQueryResult = NonNullable<
-  Awaited<ReturnType<typeof downloadExportImages>>
->;
-export type DownloadExportImagesQueryError = HTTPValidationError;
-
-/**
- * @summary Download Images
- */
-
-export function useDownloadExportImages<
-  TData = Awaited<ReturnType<typeof downloadExportImages>>,
-  TError = HTTPValidationError,
->(
-  exportId: MaybeRefOrGetter<string>,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof downloadExportImages>>,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseQueryReturnType<TData, TError> & {
-  queryKey: DataTag<QueryKey, TData, TError>;
-} {
-  const queryOptions = getDownloadExportImagesQueryOptions(exportId, options);
-
-  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
-    TData,
-    TError
-  > & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = unref(queryOptions).queryKey as DataTag<
-    QueryKey,
-    TData,
-    TError
-  >;
-
-  return query;
-}
-
-export type authLoginResponse200 = {
-  data: OAuthLoginResponse;
-  status: 200;
-};
-
-export type authLoginResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type authLoginResponseSuccess = authLoginResponse200 & {
-  headers: Headers;
-};
-export type authLoginResponseError = authLoginResponse422 & {
-  headers: Headers;
-};
-
-export type authLoginResponse =
-  authLoginResponseSuccess | authLoginResponseError;
-
-export const getAuthLoginUrl = (params: AuthLoginParams) => {
-  const normalizedParams = new URLSearchParams();
-
-  Object.entries(params || {}).forEach(([key, value]) => {
-    if (value !== undefined) {
-      normalizedParams.append(key, value === null ? 'null' : String(value));
-    }
-  });
-
-  const stringifiedParams = normalizedParams.toString();
-
-  return stringifiedParams.length > 0
-    ? `/v1/auth/login?${stringifiedParams}`
-    : `/v1/auth/login`;
-};
-
-/**
- * Return the Google OAuth authorization URL for the given callback URI.
- * @summary Oauth Login
- */
-export const authLogin = async (
-  params: AuthLoginParams,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<authLoginResponse> => {
-  return customFetch<authLoginResponse>(getAuthLoginUrl(params), {
-    ...options,
-    method: 'GET',
-  });
-};
-
-export const getAuthLoginQueryKey = (
-  params?: MaybeRefOrGetter<AuthLoginParams>,
-) => {
-  return ['v1', 'auth', 'login', ...(params ? [params] : [])] as const;
-};
-
-export const getAuthLoginQueryOptions = <
-  TData = Awaited<ReturnType<typeof authLogin>>,
-  TError = HTTPValidationError,
->(
-  params: MaybeRefOrGetter<AuthLoginParams>,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof authLogin>>, TError, TData>
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
-
-  const queryKey = getAuthLoginQueryKey(params);
-
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof authLogin>>> = ({
-    signal,
-  }) => authLogin(toValue(params), { signal, ...requestOptions });
-
-  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof authLogin>>,
-    TError,
-    TData
-  >;
-};
-
-export type AuthLoginQueryResult = NonNullable<
-  Awaited<ReturnType<typeof authLogin>>
->;
-export type AuthLoginQueryError = HTTPValidationError;
-
-/**
- * @summary Oauth Login
- */
-
-export function useAuthLogin<
-  TData = Awaited<ReturnType<typeof authLogin>>,
-  TError = HTTPValidationError,
->(
-  params: MaybeRefOrGetter<AuthLoginParams>,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof authLogin>>, TError, TData>
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseQueryReturnType<TData, TError> & {
-  queryKey: DataTag<QueryKey, TData, TError>;
-} {
-  const queryOptions = getAuthLoginQueryOptions(params, options);
-
-  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
-    TData,
-    TError
-  > & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = unref(queryOptions).queryKey as DataTag<
-    QueryKey,
-    TData,
-    TError
-  >;
-
-  return query;
-}
-
-export type authCallbackResponse200 = {
-  data: OAuthCallbackResponse;
-  status: 200;
-};
-
-export type authCallbackResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type authCallbackResponseSuccess = authCallbackResponse200 & {
-  headers: Headers;
-};
-export type authCallbackResponseError = authCallbackResponse422 & {
-  headers: Headers;
-};
-
-export type authCallbackResponse =
-  authCallbackResponseSuccess | authCallbackResponseError;
-
-export const getAuthCallbackUrl = () => {
-  return `/v1/auth/callback`;
-};
-
-/**
- * Exchange the OAuth code for a user session token.
- * @summary Oauth Callback
- */
-export const authCallback = async (
-  oAuthCallbackRequest: OAuthCallbackRequest,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<authCallbackResponse> => {
-  return customFetch<authCallbackResponse>(getAuthCallbackUrl(), {
-    ...options,
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
-    body: JSON.stringify(oAuthCallbackRequest),
-  });
-};
-
-export const getAuthCallbackMutationOptions = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof authCallback>>,
-    TError,
-    { data: OAuthCallbackRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof authCallback>>,
-  TError,
-  { data: OAuthCallbackRequest },
-  TContext
-> => {
-  const mutationKey = ['authCallback'];
-  const { mutation: mutationOptions, request: requestOptions } = options
-    ? options.mutation &&
-      'mutationKey' in options.mutation &&
-      options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey }, request: undefined };
-
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof authCallback>>,
-    { data: OAuthCallbackRequest }
-  > = (props) => {
-    const { data } = props ?? {};
-
-    return authCallback(data, requestOptions);
-  };
-
-  return { mutationFn, ...mutationOptions };
-};
-
-export type AuthCallbackMutationResult = NonNullable<
-  Awaited<ReturnType<typeof authCallback>>
->;
-export type AuthCallbackMutationBody = OAuthCallbackRequest;
-export type AuthCallbackMutationError = HTTPValidationError;
-
-/**
- * @summary Oauth Callback
- */
-export const useAuthCallback = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof authCallback>>,
-      TError,
-      { data: OAuthCallbackRequest },
-      TContext
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseMutationReturnType<
-  Awaited<ReturnType<typeof authCallback>>,
-  TError,
-  { data: OAuthCallbackRequest },
-  TContext
-> => {
-  return useMutation(getAuthCallbackMutationOptions(options), queryClient);
-};
-
-export type authCallbackRedirectResponse200 = {
-  data: OAuthCallbackResponse;
-  status: 200;
-};
-
-export type authCallbackRedirectResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type authCallbackRedirectResponseSuccess =
-  authCallbackRedirectResponse200 & {
-    headers: Headers;
-  };
-export type authCallbackRedirectResponseError =
-  authCallbackRedirectResponse422 & {
-    headers: Headers;
-  };
-
-export type authCallbackRedirectResponse =
-  authCallbackRedirectResponseSuccess | authCallbackRedirectResponseError;
-
-export const getAuthCallbackRedirectUrl = (
-  params: AuthCallbackRedirectParams,
-) => {
-  const normalizedParams = new URLSearchParams();
-
-  Object.entries(params || {}).forEach(([key, value]) => {
-    if (value !== undefined) {
-      normalizedParams.append(key, value === null ? 'null' : String(value));
-    }
-  });
-
-  const stringifiedParams = normalizedParams.toString();
-
-  return stringifiedParams.length > 0
-    ? `/v1/auth/callback?${stringifiedParams}`
-    : `/v1/auth/callback`;
-};
-
-/**
- * Handle GET OAuth callback when the backend is the redirect target.
- *
- * The callback_uri is extracted from the signed state token rather than
- * passed as a query parameter, so it is guaranteed to match the value used
- * during the original login request.
- * @summary Oauth Callback Get
- */
-export const authCallbackRedirect = async (
-  params: AuthCallbackRedirectParams,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<authCallbackRedirectResponse> => {
-  return customFetch<authCallbackRedirectResponse>(
-    getAuthCallbackRedirectUrl(params),
-    {
-      ...options,
-      method: 'GET',
-    },
-  );
-};
-
-export const getAuthCallbackRedirectQueryKey = (
-  params?: MaybeRefOrGetter<AuthCallbackRedirectParams>,
-) => {
-  return ['v1', 'auth', 'callback', ...(params ? [params] : [])] as const;
-};
-
-export const getAuthCallbackRedirectQueryOptions = <
-  TData = Awaited<ReturnType<typeof authCallbackRedirect>>,
-  TError = HTTPValidationError,
->(
-  params: MaybeRefOrGetter<AuthCallbackRedirectParams>,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof authCallbackRedirect>>,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
-
-  const queryKey = getAuthCallbackRedirectQueryKey(params);
-
-  const queryFn: QueryFunction<
-    Awaited<ReturnType<typeof authCallbackRedirect>>
-  > = ({ signal }) =>
-    authCallbackRedirect(toValue(params), { signal, ...requestOptions });
-
-  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof authCallbackRedirect>>,
-    TError,
-    TData
-  >;
-};
-
-export type AuthCallbackRedirectQueryResult = NonNullable<
-  Awaited<ReturnType<typeof authCallbackRedirect>>
->;
-export type AuthCallbackRedirectQueryError = HTTPValidationError;
-
-/**
- * @summary Oauth Callback Get
- */
-
-export function useAuthCallbackRedirect<
-  TData = Awaited<ReturnType<typeof authCallbackRedirect>>,
-  TError = HTTPValidationError,
->(
-  params: MaybeRefOrGetter<AuthCallbackRedirectParams>,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof authCallbackRedirect>>,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseQueryReturnType<TData, TError> & {
-  queryKey: DataTag<QueryKey, TData, TError>;
-} {
-  const queryOptions = getAuthCallbackRedirectQueryOptions(params, options);
-
-  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
-    TData,
-    TError
-  > & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = unref(queryOptions).queryKey as DataTag<
-    QueryKey,
-    TData,
-    TError
-  >;
-
-  return query;
-}
-
-export type listInvitationsResponse200 = {
-  data: InvitationResponse[];
-  status: 200;
-};
-
-export type listInvitationsResponseSuccess = listInvitationsResponse200 & {
-  headers: Headers;
-};
-export type listInvitationsResponse = listInvitationsResponseSuccess;
-
-export const getListInvitationsUrl = () => {
-  return `/v1/invitations`;
-};
-
-/**
- * @summary List Invitations
- */
-export const listInvitations = async (
-  options?: Parameters<typeof customFetch>[1],
-): Promise<listInvitationsResponse> => {
-  return customFetch<listInvitationsResponse>(getListInvitationsUrl(), {
-    ...options,
-    method: 'GET',
-  });
-};
-
-export const getListInvitationsQueryKey = () => {
-  return ['v1', 'invitations'] as const;
-};
-
-export const getListInvitationsQueryOptions = <
-  TData = Awaited<ReturnType<typeof listInvitations>>,
-  TError = unknown,
->(options?: {
-  query?: Partial<
-    UseQueryOptions<Awaited<ReturnType<typeof listInvitations>>, TError, TData>
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
-
-  const queryKey = getListInvitationsQueryKey();
-
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof listInvitations>>> = ({
-    signal,
-  }) => listInvitations({ signal, ...requestOptions });
-
-  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof listInvitations>>,
-    TError,
-    TData
-  >;
-};
-
-export type ListInvitationsQueryResult = NonNullable<
-  Awaited<ReturnType<typeof listInvitations>>
->;
-export type ListInvitationsQueryError = unknown;
-
-/**
- * @summary List Invitations
- */
-
-export function useListInvitations<
-  TData = Awaited<ReturnType<typeof listInvitations>>,
-  TError = unknown,
->(
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof listInvitations>>,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseQueryReturnType<TData, TError> & {
-  queryKey: DataTag<QueryKey, TData, TError>;
-} {
-  const queryOptions = getListInvitationsQueryOptions(options);
-
-  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
-    TData,
-    TError
-  > & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = unref(queryOptions).queryKey as DataTag<
-    QueryKey,
-    TData,
-    TError
-  >;
-
-  return query;
-}
-
-export type acceptInvitationResponse204 = {
-  data: void;
-  status: 204;
-};
-
-export type acceptInvitationResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type acceptInvitationResponseSuccess = acceptInvitationResponse204 & {
-  headers: Headers;
-};
-export type acceptInvitationResponseError = acceptInvitationResponse422 & {
-  headers: Headers;
-};
-
-export type acceptInvitationResponse =
-  acceptInvitationResponseSuccess | acceptInvitationResponseError;
-
-export const getAcceptInvitationUrl = (invitationId: string) => {
-  return `/v1/invitations/${invitationId}/accept`;
-};
-
-/**
- * @summary Accept Invitation
- */
-export const acceptInvitation = async (
-  invitationId: string,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<acceptInvitationResponse> => {
-  return customFetch<acceptInvitationResponse>(
-    getAcceptInvitationUrl(invitationId),
-    {
-      ...options,
-      method: 'POST',
-    },
-  );
-};
-
-export const getAcceptInvitationMutationOptions = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof acceptInvitation>>,
-    TError,
-    { invitationId: string },
-    TContext
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof acceptInvitation>>,
-  TError,
-  { invitationId: string },
-  TContext
-> => {
-  const mutationKey = ['acceptInvitation'];
-  const { mutation: mutationOptions, request: requestOptions } = options
-    ? options.mutation &&
-      'mutationKey' in options.mutation &&
-      options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey }, request: undefined };
-
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof acceptInvitation>>,
-    { invitationId: string }
-  > = (props) => {
-    const { invitationId } = props ?? {};
-
-    return acceptInvitation(invitationId, requestOptions);
-  };
-
-  return { mutationFn, ...mutationOptions };
-};
-
-export type AcceptInvitationMutationResult = NonNullable<
-  Awaited<ReturnType<typeof acceptInvitation>>
->;
-
-export type AcceptInvitationMutationError = HTTPValidationError;
-
-/**
- * @summary Accept Invitation
- */
-export const useAcceptInvitation = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof acceptInvitation>>,
-      TError,
-      { invitationId: string },
-      TContext
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseMutationReturnType<
-  Awaited<ReturnType<typeof acceptInvitation>>,
-  TError,
-  { invitationId: string },
-  TContext
-> => {
-  return useMutation(getAcceptInvitationMutationOptions(options), queryClient);
-};
-
-export type ignoreInvitationResponse204 = {
-  data: void;
-  status: 204;
-};
-
-export type ignoreInvitationResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type ignoreInvitationResponseSuccess = ignoreInvitationResponse204 & {
-  headers: Headers;
-};
-export type ignoreInvitationResponseError = ignoreInvitationResponse422 & {
-  headers: Headers;
-};
-
-export type ignoreInvitationResponse =
-  ignoreInvitationResponseSuccess | ignoreInvitationResponseError;
-
-export const getIgnoreInvitationUrl = (invitationId: string) => {
-  return `/v1/invitations/${invitationId}/ignore`;
-};
-
-/**
- * @summary Ignore Invitation
- */
-export const ignoreInvitation = async (
-  invitationId: string,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<ignoreInvitationResponse> => {
-  return customFetch<ignoreInvitationResponse>(
-    getIgnoreInvitationUrl(invitationId),
-    {
-      ...options,
-      method: 'POST',
-    },
-  );
-};
-
-export const getIgnoreInvitationMutationOptions = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof ignoreInvitation>>,
-    TError,
-    { invitationId: string },
-    TContext
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof ignoreInvitation>>,
-  TError,
-  { invitationId: string },
-  TContext
-> => {
-  const mutationKey = ['ignoreInvitation'];
-  const { mutation: mutationOptions, request: requestOptions } = options
-    ? options.mutation &&
-      'mutationKey' in options.mutation &&
-      options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey }, request: undefined };
-
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof ignoreInvitation>>,
-    { invitationId: string }
-  > = (props) => {
-    const { invitationId } = props ?? {};
-
-    return ignoreInvitation(invitationId, requestOptions);
-  };
-
-  return { mutationFn, ...mutationOptions };
-};
-
-export type IgnoreInvitationMutationResult = NonNullable<
-  Awaited<ReturnType<typeof ignoreInvitation>>
->;
-
-export type IgnoreInvitationMutationError = HTTPValidationError;
-
-/**
- * @summary Ignore Invitation
- */
-export const useIgnoreInvitation = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof ignoreInvitation>>,
-      TError,
-      { invitationId: string },
-      TContext
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseMutationReturnType<
-  Awaited<ReturnType<typeof ignoreInvitation>>,
-  TError,
-  { invitationId: string },
-  TContext
-> => {
-  return useMutation(getIgnoreInvitationMutationOptions(options), queryClient);
-};
-
-export type listBlocklistResponse200 = {
-  data: BlocklistEntryResponse[];
-  status: 200;
-};
-
-export type listBlocklistResponseSuccess = listBlocklistResponse200 & {
-  headers: Headers;
-};
-export type listBlocklistResponse = listBlocklistResponseSuccess;
-
-export const getListBlocklistUrl = () => {
-  return `/v1/invitations/blocklist`;
-};
-
-/**
- * @summary List Blocklist
- */
-export const listBlocklist = async (
-  options?: Parameters<typeof customFetch>[1],
-): Promise<listBlocklistResponse> => {
-  return customFetch<listBlocklistResponse>(getListBlocklistUrl(), {
-    ...options,
-    method: 'GET',
-  });
-};
-
-export const getListBlocklistQueryKey = () => {
-  return ['v1', 'invitations', 'blocklist'] as const;
-};
-
-export const getListBlocklistQueryOptions = <
-  TData = Awaited<ReturnType<typeof listBlocklist>>,
-  TError = unknown,
->(options?: {
-  query?: Partial<
-    UseQueryOptions<Awaited<ReturnType<typeof listBlocklist>>, TError, TData>
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
-
-  const queryKey = getListBlocklistQueryKey();
-
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof listBlocklist>>> = ({
-    signal,
-  }) => listBlocklist({ signal, ...requestOptions });
-
-  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof listBlocklist>>,
-    TError,
-    TData
-  >;
-};
-
-export type ListBlocklistQueryResult = NonNullable<
-  Awaited<ReturnType<typeof listBlocklist>>
->;
-export type ListBlocklistQueryError = unknown;
-
-/**
- * @summary List Blocklist
- */
-
-export function useListBlocklist<
-  TData = Awaited<ReturnType<typeof listBlocklist>>,
-  TError = unknown,
->(
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof listBlocklist>>, TError, TData>
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseQueryReturnType<TData, TError> & {
-  queryKey: DataTag<QueryKey, TData, TError>;
-} {
-  const queryOptions = getListBlocklistQueryOptions(options);
-
-  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
-    TData,
-    TError
-  > & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = unref(queryOptions).queryKey as DataTag<
-    QueryKey,
-    TData,
-    TError
-  >;
-
-  return query;
-}
-
-export type blockInviterResponse204 = {
-  data: void;
-  status: 204;
-};
-
-export type blockInviterResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type blockInviterResponseSuccess = blockInviterResponse204 & {
-  headers: Headers;
-};
-export type blockInviterResponseError = blockInviterResponse422 & {
-  headers: Headers;
-};
-
-export type blockInviterResponse =
-  blockInviterResponseSuccess | blockInviterResponseError;
-
-export const getBlockInviterUrl = () => {
-  return `/v1/invitations/blocklist`;
-};
-
-/**
- * @summary Block Inviter
- */
-export const blockInviter = async (
-  blocklistAddRequest: BlocklistAddRequest,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<blockInviterResponse> => {
-  return customFetch<blockInviterResponse>(getBlockInviterUrl(), {
-    ...options,
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
-    body: JSON.stringify(blocklistAddRequest),
-  });
-};
-
-export const getBlockInviterMutationOptions = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof blockInviter>>,
-    TError,
-    { data: BlocklistAddRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof blockInviter>>,
-  TError,
-  { data: BlocklistAddRequest },
-  TContext
-> => {
-  const mutationKey = ['blockInviter'];
-  const { mutation: mutationOptions, request: requestOptions } = options
-    ? options.mutation &&
-      'mutationKey' in options.mutation &&
-      options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey }, request: undefined };
-
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof blockInviter>>,
-    { data: BlocklistAddRequest }
-  > = (props) => {
-    const { data } = props ?? {};
-
-    return blockInviter(data, requestOptions);
-  };
-
-  return { mutationFn, ...mutationOptions };
-};
-
-export type BlockInviterMutationResult = NonNullable<
-  Awaited<ReturnType<typeof blockInviter>>
->;
-export type BlockInviterMutationBody = BlocklistAddRequest;
-export type BlockInviterMutationError = HTTPValidationError;
-
-/**
- * @summary Block Inviter
- */
-export const useBlockInviter = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof blockInviter>>,
-      TError,
-      { data: BlocklistAddRequest },
-      TContext
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseMutationReturnType<
-  Awaited<ReturnType<typeof blockInviter>>,
-  TError,
-  { data: BlocklistAddRequest },
-  TContext
-> => {
-  return useMutation(getBlockInviterMutationOptions(options), queryClient);
-};
-
-export type unblockUserResponse204 = {
-  data: void;
-  status: 204;
-};
-
-export type unblockUserResponse422 = {
-  data: HTTPValidationError;
-  status: 422;
-};
-
-export type unblockUserResponseSuccess = unblockUserResponse204 & {
-  headers: Headers;
-};
-export type unblockUserResponseError = unblockUserResponse422 & {
-  headers: Headers;
-};
-
-export type unblockUserResponse =
-  unblockUserResponseSuccess | unblockUserResponseError;
-
-export const getUnblockUserUrl = (blockedUserId: string) => {
-  return `/v1/invitations/blocklist/${blockedUserId}`;
-};
-
-/**
- * @summary Unblock User
- */
-export const unblockUser = async (
-  blockedUserId: string,
-  options?: Parameters<typeof customFetch>[1],
-): Promise<unblockUserResponse> => {
-  return customFetch<unblockUserResponse>(getUnblockUserUrl(blockedUserId), {
-    ...options,
-    method: 'DELETE',
-  });
-};
-
-export const getUnblockUserMutationOptions = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof unblockUser>>,
-    TError,
-    { blockedUserId: string },
-    TContext
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof unblockUser>>,
-  TError,
-  { blockedUserId: string },
-  TContext
-> => {
-  const mutationKey = ['unblockUser'];
-  const { mutation: mutationOptions, request: requestOptions } = options
-    ? options.mutation &&
-      'mutationKey' in options.mutation &&
-      options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey }, request: undefined };
-
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof unblockUser>>,
-    { blockedUserId: string }
-  > = (props) => {
-    const { blockedUserId } = props ?? {};
-
-    return unblockUser(blockedUserId, requestOptions);
-  };
-
-  return { mutationFn, ...mutationOptions };
-};
-
-export type UnblockUserMutationResult = NonNullable<
-  Awaited<ReturnType<typeof unblockUser>>
->;
-
-export type UnblockUserMutationError = HTTPValidationError;
-
-/**
- * @summary Unblock User
- */
-export const useUnblockUser = <
-  TError = HTTPValidationError,
-  TContext = unknown,
->(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof unblockUser>>,
-      TError,
-      { blockedUserId: string },
-      TContext
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseMutationReturnType<
-  Awaited<ReturnType<typeof unblockUser>>,
-  TError,
-  { blockedUserId: string },
-  TContext
-> => {
-  return useMutation(getUnblockUserMutationOptions(options), queryClient);
-};
-
-export type rootResponse200 = {
-  data: unknown;
-  status: 200;
-};
-
-export type rootResponseSuccess = rootResponse200 & {
-  headers: Headers;
-};
-export type rootResponse = rootResponseSuccess;
-
-export const getRootUrl = () => {
-  return `/`;
-};
-
-/**
- * @summary Root
- */
-export const root = async (
-  options?: Parameters<typeof customFetch>[1],
-): Promise<rootResponse> => {
-  return customFetch<rootResponse>(getRootUrl(), {
-    ...options,
-    method: 'GET',
-  });
-};
-
-export const getRootQueryKey = () => {
-  return [] as const;
-};
-
-export const getRootQueryOptions = <
-  TData = Awaited<ReturnType<typeof root>>,
-  TError = unknown,
->(options?: {
-  query?: Partial<
-    UseQueryOptions<Awaited<ReturnType<typeof root>>, TError, TData>
-  >;
-  request?: SecondParameter<typeof customFetch>;
-}) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
-
-  const queryKey = getRootQueryKey();
-
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof root>>> = ({
-    signal,
-  }) => root({ signal, ...requestOptions });
-
-  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof root>>,
-    TError,
-    TData
-  >;
-};
-
-export type RootQueryResult = NonNullable<Awaited<ReturnType<typeof root>>>;
-export type RootQueryError = unknown;
-
-/**
- * @summary Root
- */
-
-export function useRoot<
-  TData = Awaited<ReturnType<typeof root>>,
-  TError = unknown,
->(
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof root>>, TError, TData>
-    >;
-    request?: SecondParameter<typeof customFetch>;
-  },
-  queryClient?: QueryClient,
-): UseQueryReturnType<TData, TError> & {
-  queryKey: DataTag<QueryKey, TData, TError>;
-} {
-  const queryOptions = getRootQueryOptions(options);
-
-  const query = useQuery(queryOptions, queryClient) as UseQueryReturnType<
-    TData,
-    TError
-  > & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = unref(queryOptions).queryKey as DataTag<
-    QueryKey,
-    TData,
-    TError
-  >;
-
-  return query;
-}

--- a/src/generated/types/adminLoginRequest.ts
+++ b/src/generated/types/adminLoginRequest.ts
@@ -6,6 +6,6 @@
  */
 
 export interface AdminLoginRequest {
-  username: string;
   password: string;
+  username: string;
 }

--- a/src/generated/types/bodyCreateEntry.ts
+++ b/src/generated/types/bodyCreateEntry.ts
@@ -6,11 +6,11 @@
  */
 
 export interface BodyCreateEntry {
-  /** Client-generated id; retries are idempotent. */
-  entry_id: string;
-  day: string;
+  captions?: string[];
   /** @minLength 1 */
   content: string;
-  captions?: string[];
+  day: string;
+  /** Client-generated id; retries are idempotent. */
+  entry_id: string;
   images?: Blob[];
 }

--- a/src/generated/types/bodyUpdateEntry.ts
+++ b/src/generated/types/bodyUpdateEntry.ts
@@ -6,11 +6,11 @@
  */
 
 export interface BodyUpdateEntry {
-  /** @minimum 1 */
-  expected_edit_id: number;
+  captions?: string[];
   /** @minLength 1 */
   content: string;
-  captions?: string[];
-  remove_image_ids?: string[];
+  /** @minimum 1 */
+  expected_edit_id: number;
   images?: Blob[];
+  remove_image_ids?: string[];
 }

--- a/src/generated/types/deletionRequestResponse.ts
+++ b/src/generated/types/deletionRequestResponse.ts
@@ -7,11 +7,11 @@
 import type { DeletionRequestResponseState } from './deletionRequestResponseState';
 
 export interface DeletionRequestResponse {
-  id: string;
-  state: DeletionRequestResponseState;
-  error_message?: string | null;
-  failure_code?: string | null;
   attempt_count: number;
   created_at: string;
+  error_message?: string | null;
+  failure_code?: string | null;
+  id: string;
+  state: DeletionRequestResponseState;
   updated_at: string;
 }

--- a/src/generated/types/downloadURLResponse.ts
+++ b/src/generated/types/downloadURLResponse.ts
@@ -6,6 +6,6 @@
  */
 
 export interface DownloadURLResponse {
-  url: string;
   expires_in_seconds: number;
+  url: string;
 }

--- a/src/generated/types/entryContentResponse.ts
+++ b/src/generated/types/entryContentResponse.ts
@@ -7,10 +7,10 @@
 import type { ImageResponse } from './imageResponse';
 
 export interface EntryContentResponse {
-  id: string;
-  path_id: string;
+  content: string;
   day: string;
   edit_id: number;
-  content: string;
+  id: string;
   images?: ImageResponse[];
+  path_id: string;
 }

--- a/src/generated/types/entryResponse.ts
+++ b/src/generated/types/entryResponse.ts
@@ -6,8 +6,8 @@
  */
 
 export interface EntryResponse {
-  id: string;
-  path_id: string;
   day: string;
   edit_id: number;
+  id: string;
+  path_id: string;
 }

--- a/src/generated/types/exportJobResponse.ts
+++ b/src/generated/types/exportJobResponse.ts
@@ -7,12 +7,12 @@
 import type { ExportJobResponseState } from './exportJobResponseState';
 
 export interface ExportJobResponse {
-  id: string;
-  state: ExportJobResponseState;
-  requested_path_ids: string[];
+  attempt_count: number;
   created_at: string;
-  updated_at: string;
   expires_at: string | null;
   failure_code?: string | null;
-  attempt_count: number;
+  id: string;
+  requested_path_ids: string[];
+  state: ExportJobResponseState;
+  updated_at: string;
 }

--- a/src/generated/types/getEntryVersions200.ts
+++ b/src/generated/types/getEntryVersions200.ts
@@ -5,8 +5,4 @@
  * OpenAPI spec version: 0.4.0
  */
 
-export interface BlocklistEntryResponse {
-  blocked_user_id: string;
-  created_at: string;
-  id: string;
-}
+export type GetEntryVersions200 = { [key: string]: { [key: string]: number } };

--- a/src/generated/types/getEntryVersionsParams.ts
+++ b/src/generated/types/getEntryVersionsParams.ts
@@ -5,8 +5,6 @@
  * OpenAPI spec version: 0.4.0
  */
 
-export interface BlocklistEntryResponse {
-  blocked_user_id: string;
-  created_at: string;
-  id: string;
-}
+export type GetEntryVersionsParams = {
+  path_ids?: string[];
+};

--- a/src/generated/types/healthResponse.ts
+++ b/src/generated/types/healthResponse.ts
@@ -6,12 +6,12 @@
  */
 
 export interface HealthResponse {
-  /** Service health state. */
-  status: string;
-  /** Service identifier. */
-  service: string;
   /** Database connectivity status. */
   db: string;
   /** Object storage connectivity status. */
   s3: string;
+  /** Service identifier. */
+  service: string;
+  /** Service health state. */
+  status: string;
 }

--- a/src/generated/types/imageCaptionUpdateResponse.ts
+++ b/src/generated/types/imageCaptionUpdateResponse.ts
@@ -7,6 +7,6 @@
 import type { ImageResponse } from './imageResponse';
 
 export interface ImageCaptionUpdateResponse {
-  image: ImageResponse;
   edit_id: number;
+  image: ImageResponse;
 }

--- a/src/generated/types/imageDownloadResponse.ts
+++ b/src/generated/types/imageDownloadResponse.ts
@@ -6,7 +6,7 @@
  */
 
 export interface ImageDownloadResponse {
+  expires_in_seconds: number;
   image_url: string;
   thumbnail_url: string | null;
-  expires_in_seconds: number;
 }

--- a/src/generated/types/imageResponse.ts
+++ b/src/generated/types/imageResponse.ts
@@ -6,11 +6,11 @@
  */
 
 export interface ImageResponse {
-  id: string;
+  byte_size: number | null;
+  caption: string | null;
+  content_type: string | null;
   entry_id: string;
   filename: string;
-  caption: string | null;
+  id: string;
   status: string;
-  content_type: string | null;
-  byte_size: number | null;
 }

--- a/src/generated/types/index.ts
+++ b/src/generated/types/index.ts
@@ -22,6 +22,8 @@ export * from './errorDetail';
 export * from './exportCreateRequest';
 export * from './exportJobResponse';
 export * from './exportJobResponseState';
+export * from './getEntryVersions200';
+export * from './getEntryVersionsParams';
 export * from './healthResponse';
 export * from './hTTPValidationError';
 export * from './imageCaptionUpdateRequest';

--- a/src/generated/types/invitationResponse.ts
+++ b/src/generated/types/invitationResponse.ts
@@ -6,15 +6,15 @@
  */
 
 export interface InvitationResponse {
+  created_at: string;
   id: string;
-  path_id: string;
-  path_code: string;
-  path_title: string;
-  inviter_user_id: string;
-  inviter_email: string | null;
   invited_email: string;
   invited_user_id?: string | null;
+  inviter_email: string | null;
+  inviter_user_id: string;
+  path_code: string;
+  path_id: string;
+  path_title: string;
   status: string;
-  created_at: string;
   updated_at: string;
 }

--- a/src/generated/types/oAuthCallbackRequest.ts
+++ b/src/generated/types/oAuthCallbackRequest.ts
@@ -6,7 +6,7 @@
  */
 
 export interface OAuthCallbackRequest {
+  callback_uri: string;
   code: string;
   state: string;
-  callback_uri: string;
 }

--- a/src/generated/types/oAuthCallbackResponse.ts
+++ b/src/generated/types/oAuthCallbackResponse.ts
@@ -6,7 +6,7 @@
  */
 
 export interface OAuthCallbackResponse {
+  display_name: string | null;
   token: string;
   user_id: string;
-  display_name: string | null;
 }

--- a/src/generated/types/optimisticLockErrorResponse.ts
+++ b/src/generated/types/optimisticLockErrorResponse.ts
@@ -7,7 +7,7 @@
 import type { ErrorDetail } from './errorDetail';
 
 export interface OptimisticLockErrorResponse {
+  current_edit_id: number;
   error: ErrorDetail;
   expected_edit_id: number;
-  current_edit_id: number;
 }

--- a/src/generated/types/pathCreateRequest.ts
+++ b/src/generated/types/pathCreateRequest.ts
@@ -6,12 +6,12 @@
  */
 
 export interface PathCreateRequest {
+  /** @pattern ^#[0-9A-Fa-f]{6}$ */
+  color: string;
+  description?: string | null;
   /**
    * @minLength 1
    * @maxLength 120
    */
   title: string;
-  description?: string | null;
-  /** @pattern ^#[0-9A-Fa-f]{6}$ */
-  color: string;
 }

--- a/src/generated/types/pathCreationApprovalResponse.ts
+++ b/src/generated/types/pathCreationApprovalResponse.ts
@@ -6,6 +6,6 @@
  */
 
 export interface PathCreationApprovalResponse {
-  user_id: string;
   allowed: boolean;
+  user_id: string;
 }

--- a/src/generated/types/pathResponse.ts
+++ b/src/generated/types/pathResponse.ts
@@ -6,13 +6,13 @@
  */
 
 export interface PathResponse {
-  path_id: string;
-  uuid: string;
-  owner_user_id: string;
-  title: string;
-  description: string | null;
   color: string;
-  is_public: boolean;
   created_at: string;
+  description: string | null;
+  is_public: boolean;
+  owner_user_id: string;
+  path_id: string;
+  title: string;
   updated_at: string;
+  uuid: string;
 }

--- a/src/generated/types/pathUpdateRequest.ts
+++ b/src/generated/types/pathUpdateRequest.ts
@@ -6,7 +6,7 @@
  */
 
 export interface PathUpdateRequest {
-  title?: string | null;
-  description?: string | null;
   color?: string | null;
+  description?: string | null;
+  title?: string | null;
 }

--- a/src/generated/types/subscriberResponse.ts
+++ b/src/generated/types/subscriberResponse.ts
@@ -6,7 +6,7 @@
  */
 
 export interface SubscriberResponse {
-  user_id: string;
-  email: string | null;
   display_name: string | null;
+  email: string | null;
+  user_id: string;
 }

--- a/src/generated/types/userProfileResponse.ts
+++ b/src/generated/types/userProfileResponse.ts
@@ -6,7 +6,7 @@
  */
 
 export interface UserProfileResponse {
-  user_id: string;
   display_name: string | null;
   settings_json?: string | null;
+  user_id: string;
 }

--- a/src/generated/types/validationError.ts
+++ b/src/generated/types/validationError.ts
@@ -7,9 +7,9 @@
 import type { ValidationErrorCtx } from './validationErrorCtx';
 
 export interface ValidationError {
+  ctx?: ValidationErrorCtx;
+  input?: unknown;
   loc: (string | number)[];
   msg: string;
   type: string;
-  input?: unknown;
-  ctx?: ValidationErrorCtx;
 }

--- a/src/lib/authSession.ts
+++ b/src/lib/authSession.ts
@@ -1,4 +1,5 @@
 import { ref } from 'vue';
+import { clearEtags } from './etagStore';
 
 /**
  * Flips true when a request comes back 401 — the session is invalid or expired.
@@ -12,6 +13,9 @@ export function clearSession(): void {
   localStorage.removeItem('user');
   localStorage.removeItem('session_token');
   sessionExpired.value = true;
+  // Fire-and-forget: a cached response body must never survive to the next
+  // account that signs in on this browser.
+  void clearEtags();
 }
 
 const RETURN_PATH_KEY = 'post_login_redirect';

--- a/src/lib/customFetch.ts
+++ b/src/lib/customFetch.ts
@@ -1,4 +1,5 @@
 import { clearSession } from './authSession';
+import { getEtag, setEtag } from './etagStore';
 
 export interface CustomFetchOptions extends RequestInit {
   // Only fires for FormData bodies — fetch has no upload-progress hook, so this
@@ -89,19 +90,25 @@ export const customFetch = async <T>(
   // manually here would produce a malformed multipart request the server can't parse.
   const isFormData = options?.body instanceof FormData;
 
+  const method = (options?.method ?? 'GET').toUpperCase();
+  const isConditionalGet = method === 'GET';
+  const fullUrl = `${baseUrl}${url}`;
+  const cached = isConditionalGet ? await getEtag(fullUrl) : undefined;
+
   const headers: Record<string, string> = {
     ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
     ...authHeader,
+    ...(cached ? { 'If-None-Match': cached.etag } : {}),
     ...(options?.headers as Record<string, string> | undefined),
   };
 
   if (options?.onUploadProgress && isFormData) {
-    return uploadWithProgress<T>(`${baseUrl}${url}`, options, headers);
+    return uploadWithProgress<T>(fullUrl, options, headers);
   }
 
   let response: Response;
   try {
-    response = await fetch(`${baseUrl}${url}`, {
+    response = await fetch(fullUrl, {
       ...options,
       credentials: 'include',
       headers,
@@ -109,12 +116,19 @@ export const customFetch = async <T>(
   } catch {
     throw new Error(NETWORK_ERROR_MESSAGE);
   }
+  if (response.status === 304 && cached) {
+    // Server confirmed our cached body is still current — resolve as a normal
+    // 200 rather than surfacing 304 to callers, who never asked to see it.
+    return { data: cached.body, status: 200, headers: response.headers } as T;
+  }
   if (!response.ok) {
     const detail = await detailFromResponse(response);
     if (response.status === 401) clearSession();
     throw new ApiError(response.status, detail);
   }
   const data = response.status === 204 ? undefined : await response.json();
+  const etag = response.headers.get('ETag');
+  if (isConditionalGet && etag) await setEtag(fullUrl, etag, data);
   return { data, status: response.status, headers: response.headers } as T;
 };
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -10,6 +10,15 @@ export interface QueryCacheEntry {
   value: string;
 }
 
+/** One conditional-GET cache entry: the last ETag seen for a request URL and
+ *  the response body it was attached to, so a future 304 can resolve to it
+ *  without re-parsing anything. See lib/etagStore.ts. */
+export interface EtagCacheEntry {
+  url: string;
+  etag: string;
+  body: unknown;
+}
+
 /** A local-only, never-synced draft of in-progress entry text/images.
  *
  * Keyed by "pathId:day" for new entries or "pathId:entryId" for edits, so there's at most
@@ -29,6 +38,7 @@ const db = new Dexie('pathsFrontend') as Dexie & {
   pathPreferences: EntityTable<PathPreference, 'pathId'>;
   queryCache: EntityTable<QueryCacheEntry, 'key'>;
   localDrafts: EntityTable<LocalEntryDraft, 'draftKey'>;
+  etagCache: EntityTable<EtagCacheEntry, 'url'>;
 };
 
 export { db };
@@ -80,6 +90,18 @@ db.version(7).stores({
   entryContent: null,
   entryImages: null,
   localDrafts: '&draftKey,pathId',
+});
+
+// Version 8: add etagCache for conditional-GET support in lib/customFetch.ts —
+// a separate table from queryCache since it's keyed by request URL, not by
+// TanStack Query key, and needs its own clear-on-logout lifecycle.
+db.version(8).stores({
+  pathPreferences: '&pathId,hidden',
+  queryCache: '&key',
+  entryContent: null,
+  entryImages: null,
+  localDrafts: '&draftKey,pathId',
+  etagCache: '&url',
 });
 
 export async function isPathHidden(pathId: string) {

--- a/src/lib/etagStore.ts
+++ b/src/lib/etagStore.ts
@@ -1,0 +1,43 @@
+import { db } from './db';
+
+/**
+ * Per-URL conditional-GET cache backing lib/customFetch.ts. Kept as a plain
+ * URL->{etag, body} table rather than piggybacking on TanStack Query's own
+ * persisted cache (lib/queryPersister.ts), since customFetch has no notion
+ * of a query key — only the request URL it was given.
+ */
+
+export async function getEtag(
+  url: string,
+): Promise<{ etag: string; body: unknown } | undefined> {
+  try {
+    const entry = await db.etagCache.get(url);
+    if (!entry) return undefined;
+    return { etag: entry.etag, body: entry.body };
+  } catch {
+    // IndexedDB may be unavailable; behave as if nothing were cached.
+    return undefined;
+  }
+}
+
+export async function setEtag(
+  url: string,
+  etag: string,
+  body: unknown,
+): Promise<void> {
+  try {
+    await db.etagCache.put({ url, etag, body });
+  } catch {
+    // IndexedDB may be unavailable; the next request just won't send If-None-Match.
+  }
+}
+
+/** Clear all cached etags — must run on logout so a shared browser never serves
+ *  one account's cached response body to the next account that signs in. */
+export async function clearEtags(): Promise<void> {
+  try {
+    await db.etagCache.clear();
+  } catch {
+    // IndexedDB may be unavailable; nothing to clear.
+  }
+}

--- a/src/pages/entry.[pathId].[entryId].vue
+++ b/src/pages/entry.[pathId].[entryId].vue
@@ -35,9 +35,13 @@
         </div>
 
         <p class="entry-path-label">
-          <router-link v-if="path" :to="pathViewLink" class="entry-path-link">{{
-            path.title
-          }}</router-link>
+          <router-link
+            v-if="path && entryDay"
+            :to="pathViewLink"
+            class="entry-path-link"
+            >{{ path.title }}</router-link
+          >
+          <template v-else-if="path">{{ path.title }}</template>
           <template v-else>Loading…</template>
         </p>
         <h1 class="entry-date">

--- a/src/pages/entryView.stories.ts
+++ b/src/pages/entryView.stories.ts
@@ -178,6 +178,11 @@ export const PathNameLinksToPathViewCenteredOnEntryDate: Story = {
   ],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    // Wait for the entry itself to load before clicking the path name: until
+    // then the link intentionally isn't day-aware yet (see
+    // entry.[pathId].[entryId].vue), so clicking earlier would be racing the
+    // fetch rather than testing the "centered on this date" behavior.
+    await canvas.findByText(entryContentResponseFixture.content);
     await userEvent.click(await canvas.findByText(pathResponseFixture.title));
     await expect(router.currentRoute.value.fullPath).toBe(
       `/paths?pathId=${pathResponseFixture.path_id}&day=${entryContentResponseFixture.day}`,


### PR DESCRIPTION
Plans conditional-GET handling in customFetch.ts (explicit If-None-Match,
not native browser caching) and replacing per-path 25s full-list polling
in useMultiPathEntries with a single bulk version-map diff.