### PR TITLE
Stamp deployed builds with date+commit version instead of always "dev"

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only ${{ (github.event.inputs.environment == 'production' || github.event_name == 'release') && '--config fly.prod.toml' || ''}}
+      - run: |
+          VERSION="$(date -u +%Y-%m-%d)-${GITHUB_SHA::7}"
+          flyctl deploy --remote-only --build-arg VITE_APP_VERSION="$VERSION" ${{ (github.event.inputs.environment == 'production' || github.event_name == 'release') && '--config fly.prod.toml' || ''}}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:storybook:ci": "npm run build-storybook -- -o storybook-static && concurrently -k -s first \"http-server storybook-static --port 6006 --silent\" \"wait-on tcp:6006 && test-storybook --testTimeout=60000 --url http://localhost:6006\"",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "deploy": "flyctl deploy --build-arg VITE_APP_VERSION=$(git rev-parse --short HEAD)"
+    "deploy": "flyctl deploy --build-arg VITE_APP_VERSION=$(date -u +%Y-%m-%d)-$(git rev-parse --short HEAD)"
   },
   "dependencies": {
     "@capacitor/app": "^8.1.1",


### PR DESCRIPTION
CI's flyctl deploy never passed the VITE_APP_VERSION build-arg, so every
deploy fell back to the Dockerfile default of "dev". Now the workflow
(and the manual npm run deploy script) inject a YYYY-MM-DD-<sha7> tag
so the footer shows both when and exactly what commit is running.