### PR TITLE
Keep Save always visible and fix keyboard issues on entry editor

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -6,7 +6,7 @@ const config: CapacitorConfig = {
   webDir: 'dist',
   plugins: {
     Keyboard: {
-      resize: 'body',
+      resize: 'native',
     },
   },
 };

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
   <ion-app>
     <div id="ion-view-container-root">
       <ion-router-outlet />
-      <AppFooter />
+      <AppFooter v-if="!isEntryEditorRoute" />
       <SessionExpiredBanner
         :visible="sessionExpired"
         @login="showLoginModal = true"
@@ -64,8 +64,8 @@ import { IonApp, IonRouterOutlet, IonToast } from '@ionic/vue';
 import { Capacitor } from '@capacitor/core';
 import { Keyboard } from '@capacitor/keyboard';
 import { App as CapacitorApp } from '@capacitor/app';
-import { onBeforeUnmount, onMounted, ref } from 'vue';
-import { useRouter } from 'vue-router';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 import { useInstallBanner } from './composables/useInstallBanner';
 import { useVirtualKeyboard } from './composables/useVirtualKeyboard';
 import { sessionExpired } from './lib/authSession';
@@ -74,6 +74,17 @@ import SessionExpiredBanner from './components/SessionExpiredBanner.vue';
 import SessionExpiredModal from './components/SessionExpiredModal.vue';
 
 const router = useRouter();
+const route = useRoute();
+
+// AppFooter is fixed to the viewport bottom outside every page's ion-content
+// (see theme.css), which puts it right where the on-screen keyboard opens on
+// the entry write/edit screens — there's no useful place left to pin it once
+// the keyboard is up, so it's dropped entirely on those two routes instead.
+const isEntryEditorRoute = computed(
+  () =>
+    route.name === '/entry.new' ||
+    route.name === '/entry.[pathId].[entryId].edit',
+);
 
 const { deferredPrompt, promptInstall, dismissInstall } = useInstallBanner();
 

--- a/src/assets/theme.css
+++ b/src/assets/theme.css
@@ -14,10 +14,13 @@
 }
 
 /* Global (not scoped) so every page's ion-content reserves this space, since AppFooter
- * overlays every route. !important because Ionic's own `.ion-padding` utility class
- * (and any other class-based override) otherwise wins on specificity over this bare type
- * selector and silently drops the clearance back to 16px. Page-specific overrides that
- * need MORE than the floor (e.g. index.vue's bottom-bar) must also use !important to win. */
+ * overlays every route it's rendered on (all but the entry write/edit screens — see
+ * App.vue). !important because Ionic's own `.ion-padding` utility class (and any other
+ * class-based override) otherwise wins on specificity over this bare type selector and
+ * silently drops the clearance back to 16px. Page-specific overrides that need MORE or
+ * LESS than the floor (e.g. index.vue's bottom-bar, or the entry editor pages once
+ * AppFooter is hidden there) must also use !important — and a scoped selector, to
+ * out-specificity this one — to win. */
 ion-content {
   --padding-bottom: var(--app-footer-clearance) !important;
 }

--- a/src/pages/entry.[pathId].[entryId].edit.vue
+++ b/src/pages/entry.[pathId].[entryId].edit.vue
@@ -2,9 +2,7 @@
   <ion-page>
     <ion-header class="editor-toolbar-header">
       <div class="editor-header">
-        <router-link class="text-btn" :to="entryViewLink">
-          Cancel
-        </router-link>
+        <router-link class="text-btn" :to="entryViewLink"> Cancel </router-link>
         <div class="editor-header-title">
           <span class="editor-header-label">{{ path?.title }}</span>
           <span class="editor-header-date">{{ entryData?.day }}</span>

--- a/src/pages/entry.[pathId].[entryId].edit.vue
+++ b/src/pages/entry.[pathId].[entryId].edit.vue
@@ -1,24 +1,25 @@
 <template>
   <ion-page>
+    <ion-header class="editor-toolbar-header">
+      <div class="editor-header">
+        <router-link class="text-btn" :to="entryViewLink">
+          Cancel
+        </router-link>
+        <div class="editor-header-title">
+          <span class="editor-header-label">{{ path?.title }}</span>
+          <span class="editor-header-date">{{ entryData?.day }}</span>
+        </div>
+        <button
+          class="pill-btn"
+          :disabled="!content.trim() || saving"
+          @click="submit"
+        >
+          {{ saveLabel }}
+        </button>
+      </div>
+    </ion-header>
     <ion-content>
       <div class="editor-page df-ui">
-        <div class="editor-header">
-          <router-link class="text-btn" :to="entryViewLink">
-            Cancel
-          </router-link>
-          <div class="editor-header-title">
-            <span class="editor-header-label">{{ path?.title }}</span>
-            <span class="editor-header-date">{{ entryData?.day }}</span>
-          </div>
-          <button
-            class="pill-btn"
-            :disabled="!content.trim() || saving"
-            @click="submit"
-          >
-            {{ saveLabel }}
-          </button>
-        </div>
-
         <div class="editor-toolbar">
           <template v-if="contentTab === 'write'">
             <button type="button" @click="wrapSelection('**')">
@@ -143,7 +144,13 @@
 </template>
 
 <script setup lang="ts">
-import { IonAlert, IonPage, IonContent, IonTextarea } from '@ionic/vue';
+import {
+  IonAlert,
+  IonPage,
+  IonHeader,
+  IonContent,
+  IonTextarea,
+} from '@ionic/vue';
 import { computed, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useQueryClient } from '@tanstack/vue-query';
@@ -370,13 +377,26 @@ async function submit() {
   padding: 1rem var(--page-margin, 0.75rem) 2rem;
 }
 
+/* No footer clearance is reserved on this page (see ion-content override
+   below) since AppFooter is hidden here — the on-screen keyboard covering
+   it would defeat the point of keeping Save reachable while typing. */
+ion-content {
+  --padding-bottom: 1rem !important;
+}
+
+.editor-toolbar-header {
+  background: var(--color-paper);
+}
+
 .editor-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-bottom: 0.75rem;
+  max-width: 40rem;
+  margin: 0 auto;
+  padding: max(0.6rem, env(safe-area-inset-top)) var(--page-margin, 0.75rem)
+    0.75rem;
   border-bottom: 1px solid var(--color-rule);
-  margin-bottom: 1rem;
 }
 
 .text-btn {

--- a/src/pages/entry.new.vue
+++ b/src/pages/entry.new.vue
@@ -1,22 +1,23 @@
 <template>
   <ion-page>
+    <ion-header class="editor-toolbar-header">
+      <div class="editor-header">
+        <button class="text-btn" @click="goBack">Cancel</button>
+        <div class="editor-header-title">
+          <span class="editor-header-label">Entry</span>
+          <span class="editor-header-date">{{ headerDateLabel }}</span>
+        </div>
+        <button
+          class="pill-btn"
+          :disabled="!selectedPathId || !day || !content || saving"
+          @click="submit"
+        >
+          {{ saveLabel }}
+        </button>
+      </div>
+    </ion-header>
     <ion-content>
       <div class="editor-page df-ui">
-        <div class="editor-header">
-          <button class="text-btn" @click="goBack">Cancel</button>
-          <div class="editor-header-title">
-            <span class="editor-header-label">Entry</span>
-            <span class="editor-header-date">{{ headerDateLabel }}</span>
-          </div>
-          <button
-            class="pill-btn"
-            :disabled="!selectedPathId || !day || !content || saving"
-            @click="submit"
-          >
-            {{ saveLabel }}
-          </button>
-        </div>
-
         <div class="editor-meta-row">
           <select
             v-model="selectedPathId"
@@ -143,7 +144,13 @@
 </template>
 
 <script setup lang="ts">
-import { IonAlert, IonPage, IonContent, IonTextarea } from '@ionic/vue';
+import {
+  IonAlert,
+  IonPage,
+  IonHeader,
+  IonContent,
+  IonTextarea,
+} from '@ionic/vue';
 import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useQueryClient } from '@tanstack/vue-query';
@@ -317,13 +324,26 @@ async function submit() {
   padding: 1rem var(--page-margin, 0.75rem) 2rem;
 }
 
+/* No footer clearance is reserved on this page (see ion-content override
+   below) since AppFooter is hidden here — the on-screen keyboard covering
+   it would defeat the point of keeping Save reachable while typing. */
+ion-content {
+  --padding-bottom: 1rem !important;
+}
+
+.editor-toolbar-header {
+  background: var(--color-paper);
+}
+
 .editor-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-bottom: 0.75rem;
+  max-width: 40rem;
+  margin: 0 auto;
+  padding: max(0.6rem, env(safe-area-inset-top)) var(--page-margin, 0.75rem)
+    0.75rem;
   border-bottom: 1px solid var(--color-rule);
-  margin-bottom: 1rem;
 }
 
 .text-btn {


### PR DESCRIPTION
Move Cancel/Save into an ion-header above ion-content on the entry
new/edit pages so they no longer scroll out of view as the entry
grows. Switch Capacitor's Keyboard resize mode from 'body' to
'native' so the WebView viewport actually tracks the keyboard,
fixing both the textarea getting hidden behind it and the keyboard
failing to reopen on tap after being dismissed by other means. Hide
AppFooter entirely on the entry editor routes, since it's fixed to
the same viewport-bottom spot the keyboard occupies there.