### PR TITLE
Position the focus day within the week strip by recency

### DIFF
--- a/src/__tests__/focusDayIndex.test.ts
+++ b/src/__tests__/focusDayIndex.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+
+import { focusDayIndex } from '../utils/date';
+
+const TODAY = '2026-08-23';
+
+describe('focusDayIndex', () => {
+  it('places today last in the strip', () => {
+    expect(focusDayIndex('2026-08-23', TODAY)).toBe(6);
+  });
+
+  it('places yesterday second-to-last', () => {
+    expect(focusDayIndex('2026-08-22', TODAY)).toBe(5);
+  });
+
+  it('places the day before yesterday fifth', () => {
+    expect(focusDayIndex('2026-08-21', TODAY)).toBe(4);
+  });
+
+  it('centers older past days fourth', () => {
+    expect(focusDayIndex('2026-08-20', TODAY)).toBe(3);
+    expect(focusDayIndex('2026-07-01', TODAY)).toBe(3);
+  });
+
+  it('centers future days fourth', () => {
+    expect(focusDayIndex('2026-08-24', TODAY)).toBe(3);
+  });
+});

--- a/src/components/DayBrowser.vue
+++ b/src/components/DayBrowser.vue
@@ -130,7 +130,7 @@ import { IonSpinner } from '@ionic/vue';
 import type { PathResponse, ImageResponse } from '../generated/types';
 import type { PathEntries } from '../composables/useMultiPathEntries';
 import { useOnThisDay } from '../composables/useOnThisDay';
-import { toLocalISODate } from '../utils/date';
+import { focusDayIndex, toLocalISODate } from '../utils/date';
 import EntryImage from './EntryImage.vue';
 import ImageLightbox from './ImageLightbox.vue';
 
@@ -217,13 +217,13 @@ function colorsForDay(dateStr: string): string[] {
 
 const weekDays = computed<WeekDay[]>(() => {
   const base = selectedDateObj.value;
-  const sunday = new Date(base);
-  sunday.setDate(base.getDate() - base.getDay());
+  const start = new Date(base);
+  start.setDate(base.getDate() - focusDayIndex(selectedDate.value, todayStr));
 
   const days: WeekDay[] = [];
   for (let i = 0; i < 7; i++) {
-    const d = new Date(sunday);
-    d.setDate(sunday.getDate() + i);
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
     const dateStr = toLocalISODate(d);
     days.push({
       dateStr,

--- a/src/pages/index.loggedIn.stories.ts
+++ b/src/pages/index.loggedIn.stories.ts
@@ -13,7 +13,7 @@ import type {
   PathResponse,
   ImageResponse,
 } from '../generated/types';
-import { toLocalISODate } from '../utils/date';
+import { focusDayIndex, toLocalISODate } from '../utils/date';
 import {
   withAppShell,
   withLoggedInUser,
@@ -248,11 +248,12 @@ export const WriteEntryUsesTheSelectedDay: Story = {
     await userEvent.click(weekDays[otherIndex]!);
 
     // Independently derive that day's date the same way DayBrowser does —
-    // the Sun-Sat week containing today, offset by the clicked cell's index.
-    const sunday = new Date();
-    sunday.setDate(sunday.getDate() - sunday.getDay());
-    const expectedDate = new Date(sunday);
-    expectedDate.setDate(sunday.getDate() + otherIndex);
+    // a 7-day window starting focusDayIndex days before the selected day
+    // (today, by default), offset by the clicked cell's index.
+    const start = new Date();
+    start.setDate(start.getDate() - focusDayIndex(today, today));
+    const expectedDate = new Date(start);
+    expectedDate.setDate(start.getDate() + otherIndex);
     const expectedDay = toLocalISODate(expectedDate);
     expect(expectedDay).not.toBe(today);
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -11,3 +11,29 @@ export function toLocalISODate(date: Date): string {
   const day = String(date.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
 }
+
+/**
+ * Index (0-6) of the focus day within a 7-day week strip.
+ *
+ * Recent focus days are pulled toward the end of the strip so the strip
+ * never has to show days after today: today lands last (6), yesterday
+ * second-to-last (5), the day before that one earlier (4). Anything older
+ * (or in the future) is centered at index 3, with 3 days either side.
+ */
+export function focusDayIndex(focusDate: string, todayDate: string): number {
+  const focus = new Date(focusDate + 'T00:00:00');
+  const today = new Date(todayDate + 'T00:00:00');
+  const daysAgo = Math.round(
+    (today.getTime() - focus.getTime()) / (24 * 60 * 60 * 1000),
+  );
+  switch (daysAgo) {
+    case 0:
+      return 6;
+    case 1:
+      return 5;
+    case 2:
+      return 4;
+    default:
+      return 3;
+  }
+}


### PR DESCRIPTION
Previously the week strip always spanned the fixed Sun-Sat calendar
week containing the focus day. Now the focus day's slot depends on how
recent it is: today lands last, yesterday second-to-last, the day
before that one earlier, and anything older (or in the future) is
centered fourth - so the strip never needs to show days after today.