### PR TITLE
Support viewing multiple paths at once in the path view

### DIFF
--- a/src/__tests__/useMultiPathEntries.window.test.ts
+++ b/src/__tests__/useMultiPathEntries.window.test.ts
@@ -133,7 +133,7 @@ describe('useMultiPathEntries – content window', () => {
     expect(result().pathEntries.value[0]!.remainingCount).toBe(70);
 
     // loadMore grows the window and fetches the next batch.
-    result().loadMore('p1');
+    result().loadMore();
     await flushPromises();
     await flushPromises();
 
@@ -212,6 +212,105 @@ describe('useMultiPathEntries – content window', () => {
     expect(entries).toHaveLength(6);
     // Every entry that was already in the window before the refresh still is.
     expect(entries.every((e) => e.inWindow)).toBe(true);
+  });
+});
+
+describe('useMultiPathEntries – multi-path window', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('windows content by overall recency across paths, not per path', async () => {
+    // p1 posts often (40 recent entries); p2 posts rarely and only has old
+    // entries. Windowing "top 30 per path" would still fetch all 5 of p2's
+    // entries (well under its own cap) even though every one of them is far
+    // older than p1's 40th-most-recent entry — exactly the lopsided-window
+    // bug reported for a path view showing multiple paths. Windowing "top 30
+    // overall" must skip p2 entirely until the shared window grows past 40.
+    const p1Ids = Array.from({ length: 40 }, (_, i) => `e${i}`);
+    const p2Ids = Array.from({ length: 5 }, (_, i) => `f${i}`);
+    const getEntryCalls = new Set<string>();
+
+    vi.mocked(customFetch).mockImplementation((url: string) => {
+      if (url === '/v1/paths/p1/entries') {
+        return Promise.resolve({
+          data: p1Ids.map((id, i) => ({
+            id,
+            path_id: 'p1',
+            day: isoDaysAgo(i),
+            edit_id: 1,
+          })),
+          status: 200,
+          headers: new Headers(),
+        });
+      }
+      if (url === '/v1/paths/p2/entries') {
+        return Promise.resolve({
+          data: p2Ids.map((id, i) => ({
+            id,
+            path_id: 'p2',
+            day: isoDaysAgo(1000 + i), // far older than any p1 entry
+            edit_id: 1,
+          })),
+          status: 200,
+          headers: new Headers(),
+        });
+      }
+      const match = url.match(/\/v1\/paths\/(p1|p2)\/entries\/(\w+)$/);
+      if (match) {
+        getEntryCalls.add(match[2]!);
+        return Promise.resolve({
+          data: {
+            id: match[2],
+            path_id: match[1],
+            day: '2024-01-01',
+            edit_id: 1,
+            content: 'x',
+          },
+          status: 200,
+          headers: new Headers(),
+        });
+      }
+      return Promise.resolve({ data: [], status: 200, headers: new Headers() });
+    });
+
+    const pathIds = ref(['p1', 'p2']);
+    const { result } = mount1(pathIds);
+    await flushPromises();
+    await flushPromises();
+
+    expect(getEntryCalls.size).toBe(DEFAULT_CONTENT_WINDOW);
+    for (let i = 0; i < DEFAULT_CONTENT_WINDOW; i++) {
+      expect(getEntryCalls.has(`e${i}`)).toBe(true);
+    }
+    for (const id of p2Ids) {
+      expect(getEntryCalls.has(id)).toBe(false);
+    }
+
+    const p1Entries = result().pathEntries.value.find(
+      (p) => p.pathId === 'p1',
+    )!;
+    const p2Entries = result().pathEntries.value.find(
+      (p) => p.pathId === 'p2',
+    )!;
+    expect(p1Entries.hasMore).toBe(true);
+    expect(p1Entries.remainingCount).toBe(10);
+    expect(p2Entries.hasMore).toBe(true);
+    expect(p2Entries.remainingCount).toBe(5);
+    expect(p2Entries.entries.every((e) => !e.inWindow)).toBe(true);
+
+    // Growing the shared window past 40 finally reaches p2's entries too.
+    result().loadMore();
+    await flushPromises();
+    await flushPromises();
+
+    expect(getEntryCalls.size).toBe(p1Ids.length + p2Ids.length);
+    for (const id of p2Ids) {
+      expect(getEntryCalls.has(id)).toBe(true);
+    }
+    const p2After = result().pathEntries.value.find((p) => p.pathId === 'p2')!;
+    expect(p2After.hasMore).toBe(false);
+    expect(p2After.remainingCount).toBe(0);
   });
 });
 

--- a/src/components/PathBrowser.stories.ts
+++ b/src/components/PathBrowser.stories.ts
@@ -3,7 +3,10 @@ import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 
 import PathBrowser from './PathBrowser.vue';
 import type { PathResponse } from '../generated/types';
-import type { EntryWithContent } from '../composables/useMultiPathEntries';
+import type {
+  EntryWithContent,
+  PathEntries,
+} from '../composables/useMultiPathEntries';
 import { toLocalISODate } from '../utils/date';
 import { router } from '../../.storybook/router';
 
@@ -37,7 +40,7 @@ function daysAgo(n: number): string {
   return toLocalISODate(d);
 }
 
-const entries: EntryWithContent[] = [
+const p1Entries: EntryWithContent[] = [
   {
     id: 'e1',
     path_id: 'p1',
@@ -77,13 +80,26 @@ const entries: EntryWithContent[] = [
   },
 ];
 
+function pathEntriesFor(
+  pathId: string,
+  entries: EntryWithContent[],
+): PathEntries {
+  return {
+    pathId,
+    entries,
+    isListLoading: false,
+    hasMore: false,
+    remainingCount: 0,
+  };
+}
+
 const meta: Meta<typeof PathBrowser> = {
   title: 'Components/PathBrowser',
   component: PathBrowser,
   args: {
     paths: [dailyLife, samsTravel],
-    selectedPathId: 'p1',
-    entries,
+    selectedPathIds: ['p1'],
+    pathEntries: [pathEntriesFor('p1', p1Entries)],
   },
 };
 
@@ -102,17 +118,24 @@ export const Default: Story = {
     await expect(
       canvasElement.querySelector('.pb-entry-photo'),
     ).toBeInTheDocument();
+    // Only one path selected — no path badge clutters each row.
+    await expect(
+      canvasElement.querySelector('.pb-entry-path'),
+    ).not.toBeInTheDocument();
   },
 };
 
-export const SwitchingPathEmitsUpdate: Story = {
-  args: { 'onUpdate:selectedPathId': fn() },
+export const TogglingAPathEmitsUpdate: Story = {
+  args: { 'onUpdate:selectedPathIds': fn() },
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
-    const select = canvas.getByLabelText('Path') as HTMLSelectElement;
-    await userEvent.selectOptions(select, "Sam's Travel");
+    const toggle = canvas.getByRole('button', { name: "Sam's Travel" });
+    await userEvent.click(toggle);
     await waitFor(() =>
-      expect(args['onUpdate:selectedPathId']).toHaveBeenCalledWith('p2'),
+      expect(args['onUpdate:selectedPathIds']).toHaveBeenCalledWith([
+        'p1',
+        'p2',
+      ]),
     );
   },
 };
@@ -146,7 +169,7 @@ export const NavigatingAnEntryWithTheKeyboard: Story = {
 };
 
 export const NoEntriesForSelectedPath: Story = {
-  args: { entries: [] },
+  args: { pathEntries: [pathEntriesFor('p1', [])] },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(
@@ -158,7 +181,11 @@ export const NoEntriesForSelectedPath: Story = {
 // A deleted path (or a stale/bad link) — distinct from a real path that
 // simply has no entries yet.
 export const PathNotFound: Story = {
-  args: { entries: [], pathNotFound: true },
+  args: {
+    selectedPathIds: ['deleted-path'],
+    pathEntries: [],
+    notFoundPathIds: ['deleted-path'],
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(
@@ -174,15 +201,20 @@ export const PathNotFound: Story = {
 // accumulate dozens of posts, unlike Day Browser's one-per-day-per-path.
 export const ManyEntries: Story = {
   args: {
-    entries: Array.from({ length: 30 }, (_, i) => ({
-      id: `me${i}`,
-      path_id: 'p1',
-      day: daysAgo(i),
-      edit_id: 1,
-      content: `Entry ${i}`,
-      images: [],
-      inWindow: true,
-    })),
+    pathEntries: [
+      pathEntriesFor(
+        'p1',
+        Array.from({ length: 30 }, (_, i) => ({
+          id: `me${i}`,
+          path_id: 'p1',
+          day: daysAgo(i),
+          edit_id: 1,
+          content: `Entry ${i}`,
+          images: [],
+          inWindow: true,
+        })),
+      ),
+    ],
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -195,20 +227,58 @@ export const ManyEntries: Story = {
   },
 };
 
+// Multiple paths selected at once: entries from every selected path merge
+// into one feed ordered by overall recency, each row tagged with its path.
+export const MultiplePathsMergedByDate: Story = {
+  args: {
+    selectedPathIds: ['p1', 'p2'],
+    pathEntries: [
+      pathEntriesFor('p1', p1Entries),
+      pathEntriesFor('p2', [
+        {
+          id: 'f1',
+          path_id: 'p2',
+          day: daysAgo(1),
+          edit_id: 1,
+          content: 'Landed in Tokyo',
+          images: [],
+          inWindow: true,
+        },
+      ]),
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Merged in date order across paths, not grouped by path.
+    const previews = canvasElement.querySelectorAll('.pb-entry-preview');
+    await expect(previews[0]).toHaveTextContent('Today entry');
+    await expect(previews[1]).toHaveTextContent('Landed in Tokyo');
+    await expect(previews[2]).toHaveTextContent('A few days ago');
+    // Each entry is tagged with the path it belongs to.
+    await expect(await canvas.findByText("· Sam's Travel")).toBeInTheDocument();
+    await expect(await canvas.findAllByText('· Daily Life')).toHaveLength(3);
+  },
+};
+
 // ion-content clips its slotted children to a fixed-height scroll box, so this
 // decorator stands in for it — the real regression only shows up once the
 // header shares a scroll container with the entries below it.
 export const HeaderStaysVisibleWhileScrolling: Story = {
   args: {
-    entries: Array.from({ length: 30 }, (_, i) => ({
-      id: `me${i}`,
-      path_id: 'p1',
-      day: daysAgo(i),
-      edit_id: 1,
-      content: `Entry ${i}`,
-      images: [],
-      inWindow: true,
-    })),
+    pathEntries: [
+      pathEntriesFor(
+        'p1',
+        Array.from({ length: 30 }, (_, i) => ({
+          id: `me${i}`,
+          path_id: 'p1',
+          day: daysAgo(i),
+          edit_id: 1,
+          content: `Entry ${i}`,
+          images: [],
+          inWindow: true,
+        })),
+      ),
+    ],
   },
   decorators: [
     () => ({

--- a/src/components/PathBrowser.vue
+++ b/src/components/PathBrowser.vue
@@ -1,44 +1,59 @@
 <template>
   <div class="path-browser df-ui">
     <div class="pb-header">
-      <select
-        v-model="localSelectedPathId"
-        class="pb-path-select"
-        aria-label="Path"
-        :style="{ borderColor: selectedPath?.color }"
-      >
-        <option v-for="path in paths" :key="path.path_id" :value="path.path_id">
+      <div class="pb-path-toggles" role="group" aria-label="Paths shown">
+        <button
+          v-for="path in paths"
+          :key="path.path_id"
+          type="button"
+          class="pb-path-toggle"
+          :class="{ 'pb-path-toggle--on': isSelected(path.path_id) }"
+          :style="{ '--path-color': path.color }"
+          :aria-pressed="isSelected(path.path_id)"
+          @click="toggle(path.path_id)"
+        >
           {{ path.title }}
-        </option>
-      </select>
+        </button>
+      </div>
     </div>
 
     <div class="pb-entry-section">
+      <p v-if="notFoundPathIds.length > 0" class="pb-empty">
+        {{
+          notFoundPathIds.length > 1
+            ? "Some of these paths couldn't be found. They may have been deleted."
+            : "This path couldn't be found. It may have been deleted."
+        }}
+      </p>
       <div v-if="isLoading" class="pb-loading" data-testid="pb-loading">
         <ion-spinner name="crescent" aria-label="Loading entries" />
         <span>Loading entries…</span>
       </div>
-      <p v-else-if="pathNotFound" class="pb-empty">
-        This path couldn't be found. It may have been deleted.
-      </p>
       <template v-else-if="visibleEntries.length > 0">
         <div
           v-for="entry in visibleEntries"
-          :key="entry.id"
-          :ref="(el) => registerEntryEl(entry.day, el)"
+          :key="`${entry.pathId}:${entry.id}`"
+          :ref="(el) => registerEntryEl(entry.pathId, entry.day, el)"
           class="pb-entry df-path-bar"
-          :class="{ 'pb-entry--centered': entry.day === props.centerDay }"
-          :style="{ '--path-color': selectedPath?.color }"
+          :class="{
+            'pb-entry--centered': entry.day === props.centerDay,
+          }"
+          :style="{ '--path-color': entry.pathColor }"
         >
           <router-link
             class="pb-entry-main"
             :to="{
-              path: `/entry/${props.selectedPathId}/${entry.id}`,
+              path: `/entry/${entry.pathId}/${entry.id}`,
               query: { from: 'paths' },
             }"
             :aria-label="`View entry from ${dateLabel(entry.day)}`"
           >
-            <p class="pb-entry-date">{{ dateLabel(entry.day) }}</p>
+            <p class="pb-entry-date">
+              {{ dateLabel(entry.day) }}
+              <span v-if="showPathLabels" class="pb-entry-path">
+                · {{ entry.pathTitle }}</span
+              >
+            </p>
             <p class="pb-entry-preview df-body">
               <ion-spinner
                 v-if="entry.content === undefined"
@@ -50,14 +65,14 @@
               <template v-else>{{ entry.content || '(no text)' }}</template>
             </p>
           </router-link>
-          <div v-if="(entry.images?.length ?? 0) > 0" class="pb-entry-photos">
+          <div v-if="entry.images.length > 0" class="pb-entry-photos">
             <EntryImage
-              v-for="(img, idx) in entry.images!.slice(0, 3)"
+              v-for="(img, idx) in entry.images.slice(0, 3)"
               :key="img.id"
               :image-id="img.id"
               :alt="img.filename"
               class="pb-entry-photo"
-              @open="openLightbox(entry.images!, idx, entry.day)"
+              @open="openLightbox(entry.images, idx, entry.day)"
             />
           </div>
         </div>
@@ -65,7 +80,9 @@
           Load earlier entries
         </button>
       </template>
-      <p v-else class="pb-empty">No entries yet.</p>
+      <p v-else-if="notFoundPathIds.length === 0" class="pb-empty">
+        No entries yet.
+      </p>
     </div>
 
     <ImageLightbox
@@ -83,45 +100,78 @@ import { computed, nextTick, ref, watch } from 'vue';
 import { IonSpinner } from '@ionic/vue';
 
 import type { ImageResponse, PathResponse } from '../generated/types';
-import type { EntryWithContent } from '../composables/useMultiPathEntries';
+import type { PathEntries } from '../composables/useMultiPathEntries';
 import EntryImage from './EntryImage.vue';
 import ImageLightbox from './ImageLightbox.vue';
 
 const props = defineProps<{
   paths: PathResponse[];
-  selectedPathId: string;
-  entries: EntryWithContent[];
+  selectedPathIds: string[];
+  pathEntries: PathEntries[];
   isLoading?: boolean;
   hasMore?: boolean;
-  /** The selected path isn't in the user's own path list — deleted, or a stale/bad link. */
-  pathNotFound?: boolean;
+  /** Selected path ids absent from the user's own path list — deleted, or stale/bad links. */
+  notFoundPathIds?: string[];
   /** When set, scrolls to and highlights the entry for this day once it renders. */
   centerDay?: string;
 }>();
 
 const emit = defineEmits<{
-  'update:selectedPathId': [string];
+  'update:selectedPathIds': [string[]];
   'load-more': [];
 }>();
 
-const localSelectedPathId = computed({
-  get: () => props.selectedPathId,
-  set: (value: string) => emit('update:selectedPathId', value),
+const notFoundPathIds = computed(() => props.notFoundPathIds ?? []);
+
+function isSelected(pathId: string): boolean {
+  return props.selectedPathIds.includes(pathId);
+}
+
+function toggle(pathId: string) {
+  const next = isSelected(pathId)
+    ? props.selectedPathIds.filter((id) => id !== pathId)
+    : [...props.selectedPathIds, pathId];
+  emit('update:selectedPathIds', next);
+}
+
+// A path badge on every entry only earns its place once there's more than one
+// path's entries to tell apart in the merged, date-ordered feed below.
+const showPathLabels = computed(() => props.selectedPathIds.length > 1);
+
+interface MergedEntry {
+  id: string;
+  pathId: string;
+  pathTitle: string;
+  pathColor: string;
+  day: string;
+  content: string | undefined;
+  images: ImageResponse[];
+}
+
+const pathById = computed(
+  () => new Map(props.paths.map((p) => [p.path_id, p])),
+);
+
+const visibleEntries = computed<MergedEntry[]>(() => {
+  const merged: MergedEntry[] = [];
+  for (const { pathId, entries } of props.pathEntries) {
+    const path = pathById.value.get(pathId);
+    if (!path) continue;
+    for (const entry of entries) {
+      if (!entry.inWindow) continue;
+      merged.push({
+        id: entry.id,
+        pathId,
+        pathTitle: path.title,
+        pathColor: path.color,
+        day: entry.day,
+        content: entry.content,
+        images: entry.images ?? [],
+      });
+    }
+  }
+  return merged.sort((a, b) => (a.day < b.day ? 1 : a.day > b.day ? -1 : 0));
 });
-
-const selectedPath = computed(() =>
-  props.paths.find((p) => p.path_id === props.selectedPathId),
-);
-
-const sortedEntries = computed(() =>
-  [...props.entries].sort((a, b) =>
-    a.day < b.day ? 1 : a.day > b.day ? -1 : 0,
-  ),
-);
-
-const visibleEntries = computed(() =>
-  sortedEntries.value.filter((entry) => entry.inWindow),
-);
 
 const lightbox = ref<{
   images: ImageResponse[];
@@ -141,9 +191,10 @@ function dateLabel(day: string): string {
 }
 
 const entryEls = new Map<string, HTMLElement>();
-function registerEntryEl(day: string, el: unknown) {
-  if (el instanceof HTMLElement) entryEls.set(day, el);
-  else entryEls.delete(day);
+function registerEntryEl(pathId: string, day: string, el: unknown) {
+  const key = `${pathId}:${day}`;
+  if (el instanceof HTMLElement) entryEls.set(key, el);
+  else entryEls.delete(key);
 }
 
 // Scrolls to the day the caller wants this view "centred" on (e.g. arriving
@@ -154,7 +205,11 @@ watch(
   async () => {
     if (!props.centerDay) return;
     await nextTick();
-    entryEls.get(props.centerDay)?.scrollIntoView({ block: 'center' });
+    const match = visibleEntries.value.find((e) => e.day === props.centerDay);
+    if (!match) return;
+    entryEls
+      .get(`${match.pathId}:${match.day}`)
+      ?.scrollIntoView({ block: 'center' });
   },
   { immediate: true },
 );
@@ -174,14 +229,30 @@ watch(
   border-bottom: 1px solid var(--color-rule);
 }
 
-.pb-path-select {
-  border: 1px solid var(--color-rule);
+.pb-path-toggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.pb-path-toggle {
+  border: 1px solid var(--path-color, var(--color-rule));
   border-radius: 999px;
   background: none;
   font-family: var(--font-sans);
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   font-weight: 600;
-  padding: 0.35rem 0.9rem;
+  padding: 0.3rem 0.8rem;
+  color: var(--color-ink-muted);
+  cursor: pointer;
+}
+
+.pb-path-toggle--on {
+  background: color-mix(
+    in srgb,
+    var(--path-color, var(--color-ink)) 15%,
+    transparent
+  );
   color: var(--color-ink);
 }
 
@@ -251,6 +322,10 @@ watch(
   letter-spacing: 0.06em;
   color: var(--color-ink-muted);
   text-transform: uppercase;
+}
+
+.pb-entry-path {
+  color: var(--path-color, var(--color-ink-muted));
 }
 
 .pb-entry-preview {

--- a/src/components/PathBrowser.vue
+++ b/src/components/PathBrowser.vue
@@ -325,7 +325,10 @@ watch(
 }
 
 .pb-entry-path {
-  color: var(--path-color, var(--color-ink-muted));
+  /* Not --path-color: an arbitrary user-chosen path color can't be guaranteed
+     to meet text contrast against the paper background (unlike its use as a
+     decorative accent bar/border elsewhere), so this stays a fixed ink tone. */
+  color: var(--color-ink-muted);
 }
 
 .pb-entry-preview {

--- a/src/composables/useMultiPathEntries.ts
+++ b/src/composables/useMultiPathEntries.ts
@@ -71,12 +71,17 @@ function byDayDesc(a: EntryResponse, b: EntryResponse): number {
  *
  * `entries` always includes every entry a path has (cheap: just id/day/edit_id from
  * `listEntries`), so day-membership checks (calendar dots, "on this day") never regress —
- * but each entry's `content`/`images` are only fetched for a bounded, per-path "requested"
- * window, since fetching-and-rendering everything at once for a long-lived path is what made
- * opening it freeze the UI. The window starts as the `windowSize` most recent entries (by
- * day) and only ever grows (via `loadMore`/`ensureDayLoaded`), so an entry already shown
- * never disappears again just because a background refresh reshuffled what "most recent"
- * means (e.g. a new entry synced in from another device).
+ * but each entry's `content`/`images` are only fetched for a bounded "requested" window,
+ * since fetching-and-rendering everything at once for a long-lived path is what made
+ * opening it freeze the UI. That window is shared across every selected path — the
+ * `windowSize` most recent entries overall, not per path — so a page showing several
+ * paths at once stays in one coherent, date-ordered recency window instead of each path
+ * independently loading its own most-recent N regardless of how they interleave once
+ * merged (a rarely-updated path would otherwise keep showing entries from years ago next
+ * to a busy path's last few weeks). The window only ever grows (via `loadMore`/
+ * `ensureDayLoaded`), so an entry already shown never disappears again just because a
+ * background refresh reshuffled what "most recent" means (e.g. a new entry synced in from
+ * another device).
  *
  * When an edit_id bump replaces one content query with another (same entry, new key),
  * `lastGoodContent` keeps that entry's previous content/images on screen until the new
@@ -158,39 +163,33 @@ export function useMultiPathEntries(
   // records rebuilt immutably on change (rather than mutated Sets/Maps) to keep Vue's
   // reactivity straightforward. Only ever grows for a given pathId.
   const requestedIds = ref<Record<string, Record<string, true>>>({});
-  // Per-path recency cap, raised by loadMore(). Kept separate from requestedIds so a
-  // background refresh that reorders "most recent" can still grow requestedIds to match.
-  const caps = ref<Record<string, number>>({});
+  // Recency cap shared across every selected path, raised by loadMore(). The window is
+  // "the N most recent entries overall", not "N per path" — otherwise a rarely-updated
+  // path would still have its oldest entries loaded just because they fit under its own
+  // cap, showing up out of place once merged into one date-ordered feed with a
+  // frequently-updated path. Kept separate from requestedIds so a background refresh
+  // that reorders "most recent" can still grow requestedIds to match.
+  const globalCap = ref(windowSize);
 
-  function capFor(pathId: string): number {
-    return caps.value[pathId] ?? windowSize;
-  }
-
-  function growRequested(pathId: string, sortedEntries: EntryResponse[]) {
-    const existing = requestedIds.value[pathId] ?? {};
-    const cap = capFor(pathId);
+  function growRequested() {
+    const merged = entryLists.value
+      .flatMap(({ entries }) => entries)
+      .sort(byDayDesc);
     let changed = false;
-    const next = { ...existing };
-    for (const entry of sortedEntries.slice(0, cap)) {
-      if (!next[entry.id]) {
-        next[entry.id] = true;
+    const next = { ...requestedIds.value };
+    for (const entry of merged.slice(0, globalCap.value)) {
+      const existingForPath = next[entry.path_id] ?? {};
+      if (!existingForPath[entry.id]) {
+        next[entry.path_id] = { ...existingForPath, [entry.id]: true };
         changed = true;
       }
     }
     if (changed) {
-      requestedIds.value = { ...requestedIds.value, [pathId]: next };
+      requestedIds.value = next;
     }
   }
 
-  watch(
-    entryLists,
-    (lists) => {
-      for (const { pathId, entries } of lists) {
-        growRequested(pathId, [...entries].sort(byDayDesc));
-      }
-    },
-    { immediate: true, deep: true },
-  );
+  watch(entryLists, growRequested, { immediate: true, deep: true });
 
   const windowedEntryLists = computed(() =>
     entryLists.value.map(({ pathId, entries, isListLoading }) => {
@@ -262,10 +261,9 @@ export function useMultiPathEntries(
     }
   }
 
-  function loadMore(pathId: string) {
-    caps.value = { ...caps.value, [pathId]: capFor(pathId) + windowSize };
-    const current = entryLists.value.find((p) => p.pathId === pathId);
-    if (current) growRequested(pathId, [...current.entries].sort(byDayDesc));
+  function loadMore() {
+    globalCap.value += windowSize;
+    growRequested();
   }
 
   const pathEntries = computed<PathEntries[]>(() => {

--- a/src/pages/paths.loggedIn.stories.ts
+++ b/src/pages/paths.loggedIn.stories.ts
@@ -147,7 +147,7 @@ export const MultiplePathsMergedByDate: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(
-      canvas.getByRole('button', { name: ownedPath.title }),
+      await canvas.findByRole('button', { name: ownedPath.title }),
     ).toBeInTheDocument();
     await expect(
       canvas.getByRole('button', { name: secondPath.title }),

--- a/src/pages/paths.loggedIn.stories.ts
+++ b/src/pages/paths.loggedIn.stories.ts
@@ -23,6 +23,16 @@ const today = toLocalISODate(new Date());
 // canCreateAny (which gates "+ Write Entry") requires owning a visible path.
 const ownedPath = { ...pathResponseFixture, owner_user_id: 'user-1' };
 
+const secondPath = {
+  ...pathResponseFixture,
+  path_id: 'p2',
+  uuid: 'u2',
+  title: "Sam's Travel",
+  color: '#f5a623',
+  owner_user_id: 'user-2',
+  is_public: true,
+};
+
 const mswHandlers = withDefaultHandlers(
   http.get('*/v1/paths', () => HttpResponse.json([ownedPath])),
   http.get('*/v1/paths/:pathCode/entries', () =>
@@ -56,7 +66,9 @@ export const FullPage: Story = {
         exact: false,
       }),
     ).toBeInTheDocument();
-    await expect(canvas.getByLabelText('Path')).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: ownedPath.title }),
+    ).toBeInTheDocument();
     await expect(
       canvas.getByRole('link', { name: '+ Write Entry' }),
     ).toBeInTheDocument();
@@ -90,6 +102,65 @@ export const PathNotFound: Story = {
         "This path couldn't be found. It may have been deleted.",
         { exact: false },
       ),
+    ).toBeInTheDocument();
+  },
+};
+
+// With no ?pathId in the URL, every visible path is shown at once and their
+// entries merge into a single feed ordered by overall recency — not grouped
+// per path — with each row tagged by which path it came from.
+export const MultiplePathsMergedByDate: Story = {
+  parameters: {
+    msw: {
+      handlers: withDefaultHandlers(
+        http.get('*/v1/paths', () =>
+          HttpResponse.json([ownedPath, secondPath]),
+        ),
+        http.get('*/v1/paths/:pathCode/entries', ({ params }) =>
+          HttpResponse.json([
+            {
+              ...entryResponseFixture,
+              id: `${params.pathCode}-e1`,
+              path_id: params.pathCode as string,
+              day: today,
+            },
+          ]),
+        ),
+        http.get('*/v1/paths/:pathCode/entries/:entrySlug', ({ params }) =>
+          HttpResponse.json({
+            ...entryContentResponseFixture,
+            id: params.entrySlug as string,
+            path_id: params.pathCode as string,
+            day: today,
+            content:
+              params.pathCode === secondPath.path_id
+                ? 'Landed in Tokyo'
+                : 'Wrote in my journal',
+          }),
+        ),
+        http.get('*/v1/paths/:pathCode/entries/:entrySlug/images', () =>
+          HttpResponse.json([]),
+        ),
+      ),
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('button', { name: ownedPath.title }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: secondPath.title }),
+    ).toBeInTheDocument();
+    await expect(
+      await canvas.findByText('Wrote in my journal', { exact: false }),
+    ).toBeInTheDocument();
+    await expect(
+      await canvas.findByText('Landed in Tokyo', { exact: false }),
+    ).toBeInTheDocument();
+    // More than one path selected — each row is tagged with its own path.
+    await expect(
+      await canvas.findByText(`· ${secondPath.title}`),
     ).toBeInTheDocument();
   },
 };

--- a/src/pages/paths.vue
+++ b/src/pages/paths.vue
@@ -4,13 +4,12 @@
       <PathBrowser
         v-if="currentUser"
         :paths="visiblePaths"
-        v-model:selected-path-id="selectedPathId"
-        :entries="selectedPathEntries"
-        :is-loading="selectedPathIsLoading"
-        :has-more="selectedPathHasMore"
-        :path-not-found="selectedPathNotFound"
+        v-model:selected-path-ids="selectedPathIds"
+        :path-entries="multiPathEntries"
+        :has-more="anyPathHasMore"
+        :not-found-path-ids="notFoundPathIds"
         :center-day="centerDay"
-        @load-more="loadMore(selectedPathId)"
+        @load-more="loadMore()"
       />
     </ion-content>
 
@@ -20,7 +19,7 @@
       alt-label="Browse days"
       alt-to="/"
       :can-create="canCreateAny"
-      :write-entry-query="{ day: todayStr, pathId: selectedPathId }"
+      :write-entry-query="{ day: todayStr, pathId: writeEntryPathId }"
     />
   </ion-page>
 </template>
@@ -47,14 +46,21 @@ const { visiblePaths } = usePathVisibility(allPaths);
 const centerDay =
   typeof route.query.day === 'string' ? route.query.day : undefined;
 
-const selectedPathId = ref(
-  typeof route.query.pathId === 'string' ? route.query.pathId : '',
-);
+// Repeated ?pathId=a&pathId=b query params select multiple paths; a single
+// ?pathId=a still works (vue-router hands it back as a plain string). No
+// pathId at all defaults to every currently-visible path once they load.
+function pathIdsFromQuery(): string[] {
+  const raw = route.query.pathId;
+  if (Array.isArray(raw)) return raw.filter((v): v is string => !!v);
+  return typeof raw === 'string' ? [raw] : [];
+}
+
+const selectedPathIds = ref<string[]>(pathIdsFromQuery());
 watch(
   visiblePaths,
   (paths) => {
-    if (!selectedPathId.value && paths.length > 0) {
-      selectedPathId.value = paths[0]!.path_id;
+    if (selectedPathIds.value.length === 0 && paths.length > 0) {
+      selectedPathIds.value = paths.map((p) => p.path_id);
     }
   },
   { immediate: true },
@@ -63,16 +69,14 @@ watch(
 // Checked against allPaths (not visiblePaths, which also excludes paths the
 // user has merely hidden) — a pathId absent from the user's own path list
 // entirely means deleted, or a stale/bad link, not a display preference.
-const selectedPathNotFound = computed(
-  () =>
-    !pathsLoading.value &&
-    !!selectedPathId.value &&
-    !allPaths.value?.some((p) => p.path_id === selectedPathId.value),
+const notFoundPathIds = computed(() =>
+  pathsLoading.value
+    ? []
+    : selectedPathIds.value.filter(
+        (id) => !allPaths.value?.some((p) => p.path_id === id),
+      ),
 );
 
-const selectedPathIds = computed(() =>
-  selectedPathId.value ? [selectedPathId.value] : [],
-);
 const {
   pathEntries: multiPathEntries,
   loadMore,
@@ -86,15 +90,21 @@ watch(
   },
   { immediate: true },
 );
-const selectedPathEntries = computed(
-  () => multiPathEntries.value[0]?.entries ?? [],
+
+const anyPathHasMore = computed(() =>
+  multiPathEntries.value.some((pe) => pe.hasMore),
 );
-const selectedPathIsLoading = computed(
-  () => multiPathEntries.value[0]?.isListLoading ?? false,
-);
-const selectedPathHasMore = computed(
-  () => multiPathEntries.value[0]?.hasMore ?? false,
-);
+
+// New entries need a single path to attach to — the first selected path the
+// current user owns, falling back to the first selected path at all.
+const writeEntryPathId = computed(() => {
+  const owned = visiblePaths.value.find(
+    (p) =>
+      selectedPathIds.value.includes(p.path_id) &&
+      p.owner_user_id === currentUser.value?.user_id,
+  );
+  return owned?.path_id ?? selectedPathIds.value[0];
+});
 
 const todayStr = toLocalISODate(new Date());
 

--- a/src/pages/paths.vue
+++ b/src/pages/paths.vue
@@ -6,6 +6,7 @@
         :paths="visiblePaths"
         v-model:selected-path-ids="selectedPathIds"
         :path-entries="multiPathEntries"
+        :is-loading="anyPathIsListLoading"
         :has-more="anyPathHasMore"
         :not-found-path-ids="notFoundPathIds"
         :center-day="centerDay"
@@ -91,6 +92,9 @@ watch(
   { immediate: true },
 );
 
+const anyPathIsListLoading = computed(() =>
+  multiPathEntries.value.some((pe) => pe.isListLoading),
+);
 const anyPathHasMore = computed(() =>
   multiPathEntries.value.some((pe) => pe.hasMore),
 );


### PR DESCRIPTION
Fetch and window entry content by overall recency across every selected
path instead of per path, so paths with different posting frequencies
merge into one coherent date-ordered feed instead of each independently
loading its own most-recent N entries. paths.vue now supports selecting
multiple paths (repeated ?pathId= query params, defaulting to all
visible paths), and PathBrowser renders their entries merged by date
with a per-entry path badge when more than one is selected.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T94d6ns6ua7FH6pVm6p9j4