### PR TITLE
Add native date jump on the day browser and fix week-strip positioning

### DIFF
--- a/src/__tests__/DayBrowser.futureDatePosition.test.ts
+++ b/src/__tests__/DayBrowser.futureDatePosition.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import DayBrowser from '../components/DayBrowser.vue';
+import { toLocalISODate } from '../utils/date';
+
+const stubs = {
+  IonSpinner: { template: '<span />' },
+  EntryImage: { template: '<div />' },
+  ImageLightbox: { template: '<div />' },
+};
+
+function daysFromNow(offset: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + offset);
+  return toLocalISODate(d);
+}
+
+function selectedWeekDayIndex(wrapper: ReturnType<typeof mount>): number {
+  return wrapper
+    .findAll('.db-week-day')
+    .findIndex((d) => d.classes().includes('db-week-day--selected'));
+}
+
+describe('DayBrowser future date positioning', () => {
+  it('centers tomorrow at the 4th position (index 3) when jumped to via the date picker', async () => {
+    const wrapper = mount(DayBrowser, {
+      props: {
+        visiblePaths: [],
+        pathEntries: [],
+        currentUserId: 'u1',
+        ensureDayLoaded: () => {},
+      },
+      global: { stubs },
+    });
+
+    const input = wrapper.find('.db-date-input');
+    (input.element as HTMLInputElement).value = daysFromNow(1);
+    await input.trigger('change');
+
+    expect(selectedWeekDayIndex(wrapper)).toBe(3);
+  });
+
+  it('centers any future day (not just tomorrow) at the 4th position', async () => {
+    const wrapper = mount(DayBrowser, {
+      props: {
+        visiblePaths: [],
+        pathEntries: [],
+        currentUserId: 'u1',
+        ensureDayLoaded: () => {},
+      },
+      global: { stubs },
+    });
+
+    const input = wrapper.find('.db-date-input');
+    (input.element as HTMLInputElement).value = daysFromNow(10);
+    await input.trigger('change');
+
+    expect(selectedWeekDayIndex(wrapper)).toBe(3);
+  });
+});

--- a/src/__tests__/DayBrowser.futureDatePosition.test.ts
+++ b/src/__tests__/DayBrowser.futureDatePosition.test.ts
@@ -23,6 +23,26 @@ function selectedWeekDayIndex(wrapper: ReturnType<typeof mount>): number {
 }
 
 describe('DayBrowser future date positioning', () => {
+  it('places today 6th (index 5), leaving the last slot for tomorrow', () => {
+    const wrapper = mount(DayBrowser, {
+      props: {
+        visiblePaths: [],
+        pathEntries: [],
+        currentUserId: 'u1',
+        ensureDayLoaded: () => {},
+      },
+      global: { stubs },
+    });
+
+    expect(selectedWeekDayIndex(wrapper)).toBe(5);
+
+    const cells = wrapper.findAll('.db-week-day');
+    expect(cells).toHaveLength(7);
+    expect(cells[6]!.find('.db-week-daynum').text()).toBe(
+      String(new Date(daysFromNow(1) + 'T00:00:00').getDate()),
+    );
+  });
+
   it('centers tomorrow at the 4th position (index 3) when jumped to via the date picker', async () => {
     const wrapper = mount(DayBrowser, {
       props: {

--- a/src/__tests__/focusDayIndex.test.ts
+++ b/src/__tests__/focusDayIndex.test.ts
@@ -5,19 +5,16 @@ import { focusDayIndex } from '../utils/date';
 const TODAY = '2026-08-23';
 
 describe('focusDayIndex', () => {
-  it('places today last in the strip', () => {
-    expect(focusDayIndex('2026-08-23', TODAY)).toBe(6);
+  it('places today 6th, leaving the last slot for tomorrow', () => {
+    expect(focusDayIndex('2026-08-23', TODAY)).toBe(5);
   });
 
-  it('places yesterday second-to-last', () => {
-    expect(focusDayIndex('2026-08-22', TODAY)).toBe(5);
-  });
-
-  it('places the day before yesterday fifth', () => {
-    expect(focusDayIndex('2026-08-21', TODAY)).toBe(4);
+  it('places yesterday 5th', () => {
+    expect(focusDayIndex('2026-08-22', TODAY)).toBe(4);
   });
 
   it('centers older past days fourth', () => {
+    expect(focusDayIndex('2026-08-21', TODAY)).toBe(3);
     expect(focusDayIndex('2026-08-20', TODAY)).toBe(3);
     expect(focusDayIndex('2026-07-01', TODAY)).toBe(3);
   });

--- a/src/components/DayBrowser.vue
+++ b/src/components/DayBrowser.vue
@@ -4,7 +4,18 @@
     <div class="db-header">
       <div class="db-header-text">
         <span class="db-weekday">{{ weekdayLabel }}</span>
-        <h1 class="db-date">{{ longDateLabel }}</h1>
+        <div class="db-date-picker">
+          <h1 class="db-date">{{ longDateLabel }}</h1>
+          <input
+            ref="dateInputEl"
+            type="date"
+            class="db-date-input"
+            :value="selectedDate"
+            aria-label="Jump to date"
+            @click="openDatePicker"
+            @change="onDateInputChange"
+          />
+        </div>
       </div>
       <div class="db-header-actions">
         <button
@@ -160,6 +171,24 @@ function shiftDay(delta: number) {
 
 function selectDay(dateStr: string) {
   selectedDate.value = dateStr;
+}
+
+const dateInputEl = ref<HTMLInputElement | null>(null);
+
+function openDatePicker() {
+  // showPicker() is unsupported in some browsers (older Safari) — the plain
+  // click that triggers this handler already opens the native date input's
+  // picker there, so a missing/throwing showPicker is safe to ignore.
+  try {
+    dateInputEl.value?.showPicker?.();
+  } catch {
+    // ignore — no-op fallback to the browser's default click behavior
+  }
+}
+
+function onDateInputChange(event: Event) {
+  const value = (event.target as HTMLInputElement).value;
+  if (value) selectedDate.value = value;
 }
 
 const todayStr = toLocalISODate(new Date());
@@ -347,6 +376,23 @@ defineExpose({ selectedDate });
   font-weight: 400;
   font-size: 1.6rem;
   color: var(--color-ink);
+}
+
+.db-date-picker {
+  position: relative;
+  display: inline-block;
+}
+
+.db-date-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+  border: none;
+  padding: 0;
+  margin: 0;
 }
 
 .db-header-actions {

--- a/src/pages/index.loggedIn.stories.ts
+++ b/src/pages/index.loggedIn.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/vue3';
-import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { expect, fireEvent, userEvent, waitFor, within } from 'storybook/test';
 import { http, HttpResponse } from 'msw';
 
 import IndexPage from './index.vue';
@@ -404,6 +404,38 @@ export const SelectingADayFiltersEntries: Story = {
     await expect(
       canvas.queryByText('Arrived in Kyoto! First impressions overwhelming.'),
     ).not.toBeInTheDocument();
+  },
+};
+
+export const SelectingBigDateJumpsToChosenDay: Story = {
+  parameters: { msw: { handlers: dayBrowserDefaultHandlers } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(
+        'Arrived in Kyoto! First impressions overwhelming.',
+      ),
+    ).toBeInTheDocument();
+
+    // The spelled-out big date has a native <input type="date"> overlaid on
+    // it — changing its value (as the native picker would) should jump the
+    // whole browser to that day, same as clicking a week-strip cell does.
+    const dateInput = canvasElement.querySelector(
+      '.db-date-input',
+    ) as HTMLInputElement;
+    const target = lastYearToday();
+    dateInput.value = target;
+    await fireEvent.change(dateInput);
+
+    await expect(
+      canvas.queryByText('Arrived in Kyoto! First impressions overwhelming.'),
+    ).not.toBeInTheDocument();
+    await expect(
+      await canvas.findByText(
+        'First day of spring last year — walked home through the park.',
+      ),
+    ).toBeInTheDocument();
+    await expect(dateInput.value).toBe(target);
   },
 };
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -15,10 +15,11 @@ export function toLocalISODate(date: Date): string {
 /**
  * Index (0-6) of the focus day within a 7-day week strip.
  *
- * Recent focus days are pulled toward the end of the strip so the strip
- * never has to show days after today: today lands last (6), yesterday
- * second-to-last (5), the day before that one earlier (4). Anything older
- * (or in the future) is centered at index 3, with 3 days either side.
+ * Recent focus days are pulled toward the end of the strip, but stop one
+ * short of the last slot: today lands 6th (index 5), yesterday 5th (index
+ * 4). That trailing slot always holds the day after the focus day, so
+ * looking at today (or yesterday) still shows a peek at tomorrow. Anything
+ * older, or in the future, is centered at index 3, with 3 days either side.
  */
 export function focusDayIndex(focusDate: string, todayDate: string): number {
   const focus = new Date(focusDate + 'T00:00:00');
@@ -28,10 +29,8 @@ export function focusDayIndex(focusDate: string, todayDate: string): number {
   );
   switch (daysAgo) {
     case 0:
-      return 6;
-    case 1:
       return 5;
-    case 2:
+    case 1:
       return 4;
     default:
       return 3;


### PR DESCRIPTION
## Summary
- Overlay an invisible native `<input type="date">` on the day browser's big spelled-out date header, so clicking it opens the browser's native date picker and jumping to a chosen day updates the selected day like any other day-selection action.
- Fix `focusDayIndex()`'s week-strip positioning: today now lands 6th (index 5) instead of last (index 6), and yesterday moves to 5th (index 4). The freed-up last slot always shows the day after the focus day, so looking at today or yesterday gives a peek at tomorrow. Any other day — older past or any future date — stays centered at the 4th position (index 3).

## Test plan
- [x] `vue-tsc -b` passes
- [x] `vitest run --project=unit` passes (143 tests), including new regression coverage in `DayBrowser.futureDatePosition.test.ts` and updated `focusDayIndex.test.ts`
- [x] `prettier --check` passes on changed files
- [ ] Storybook browser-mode story `SelectingBigDateJumpsToChosenDay` (added to `index.loggedIn.stories.ts`) — could not run in this sandbox due to a Playwright browser version mismatch unrelated to this change; worth confirming in CI


---
_Generated by [Claude Code](https://claude.ai/code/session_01GT74NqnTvw976nhNUdA5Bu)_