### PR TITLE
Fix logout not clearing session state, and path-visibility toggle not reaching other pages

### DIFF
--- a/.storybook/decorators.ts
+++ b/.storybook/decorators.ts
@@ -2,6 +2,7 @@ import { IonApp } from '@ionic/vue';
 
 import { router } from './router';
 import { db } from '../src/lib/db';
+import { setCurrentUser, logout } from '../src/lib/authSession';
 import AppFooter from '../src/components/AppFooter.vue';
 
 interface StoryUser {
@@ -16,12 +17,18 @@ const DEFAULT_USER: StoryUser = {
   display_name: 'Alex M.',
 };
 
-/** Decorator: seeds localStorage as if `user` had already logged in. */
+/**
+ * Decorator: seeds localStorage as if `user` had already logged in. Goes
+ * through setCurrentUser() rather than writing localStorage directly — pages
+ * read the shared `currentUser` ref from lib/authSession.ts (populated once
+ * at module load), not localStorage on every render, so a later story
+ * reaching around it would never be seen.
+ */
 export function withLoggedInUser(user: StoryUser = DEFAULT_USER) {
   return (story: () => unknown) => ({
     components: { story },
     setup() {
-      localStorage.setItem('user', JSON.stringify(user));
+      setCurrentUser(user);
     },
     template: '<story />',
   });
@@ -43,13 +50,12 @@ export function withAppShell() {
   });
 }
 
-/** Decorator: clears any logged-in user from localStorage. */
+/** Decorator: clears any logged-in user, mirroring the real logout(). */
 export function withLoggedOut() {
   return (story: () => unknown) => ({
     components: { story },
     setup() {
-      localStorage.removeItem('user');
-      localStorage.removeItem('session_token');
+      logout();
     },
     template: '<story />',
   });

--- a/src/__tests__/authSession.logout.test.ts
+++ b/src/__tests__/authSession.logout.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../lib/etagStore', () => ({
+  clearEtags: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { currentUser, setCurrentUser, logout } from '../lib/authSession';
+import type { OAuthCallbackResponse } from '../generated/types';
+
+const user: OAuthCallbackResponse = {
+  token: 'tok',
+  user_id: 'u1',
+  display_name: 'Ada',
+};
+
+describe('authSession logout', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    currentUser.value = null;
+  });
+
+  it('clears the shared currentUser, not just localStorage, so every page reflects the logout', () => {
+    setCurrentUser(user);
+    expect(currentUser.value?.user_id).toBe('u1');
+
+    logout();
+
+    // Before this fix, settings.vue's logout() only removed the localStorage
+    // keys — any page already mounted (Ionic's router-outlet keeps previous
+    // pages alive rather than remounting them) kept its own stale, one-shot
+    // "currentUser" ref and went on rendering the logged-in view.
+    expect(currentUser.value).toBeNull();
+    expect(localStorage.getItem('user')).toBeNull();
+    expect(localStorage.getItem('session_token')).toBeNull();
+  });
+
+  it('setCurrentUser makes the login immediately visible to every consumer of the shared ref', () => {
+    expect(currentUser.value).toBeNull();
+    setCurrentUser(user);
+    expect(currentUser.value).toEqual(user);
+    expect(JSON.parse(localStorage.getItem('user')!)).toEqual(user);
+  });
+});

--- a/src/__tests__/usePathVisibility.sharedState.test.ts
+++ b/src/__tests__/usePathVisibility.sharedState.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { flushPromises } from '@vue/test-utils';
+import type { PathResponse } from '../generated/types';
+
+const hidden = new Map<string, boolean>();
+
+vi.mock('../lib/db', () => ({
+  isPathHidden: vi.fn((pathId: string) =>
+    Promise.resolve(hidden.get(pathId) ?? false),
+  ),
+  setPathHidden: vi.fn((pathId: string, value: boolean) => {
+    hidden.set(pathId, value);
+    return Promise.resolve();
+  }),
+  getPathOrder: vi.fn().mockReturnValue([]),
+  setPathOrder: vi.fn(),
+}));
+
+import { usePathVisibility } from '../composables/usePathVisibility';
+
+const path: PathResponse = {
+  path_id: 'p1',
+  uuid: '11111111-1111-1111-1111-111111111111',
+  owner_user_id: 'u1',
+  title: 'My Path',
+  description: null,
+  color: '#3880ff',
+  is_public: false,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+};
+
+describe('usePathVisibility — shared visibility state', () => {
+  beforeEach(() => {
+    hidden.clear();
+    // Reset the module-level shared ref between tests via a throwaway instance.
+    usePathVisibility(ref([])).hiddenByPath.value = {};
+  });
+
+  it('reflects a toggle made through one instance (Settings) in another already-mounted instance (the Week/Paths view)', async () => {
+    const weekView = usePathVisibility(ref<PathResponse[]>([path]));
+    const settings = usePathVisibility(ref<PathResponse[]>([path]));
+    await flushPromises();
+
+    expect(weekView.visiblePaths.value.map((p) => p.path_id)).toEqual(['p1']);
+
+    await settings.toggleVisibility('p1');
+    await flushPromises();
+
+    // Before this fix, hiddenByPath was a per-call ref: toggling in the
+    // Settings instance never touched the Week view's own copy, so a path
+    // hidden in Settings kept showing in the Week/Paths view (and vice
+    // versa) until that page happened to remount.
+    expect(weekView.hiddenByPath.value.p1).toBe(true);
+    expect(weekView.visiblePaths.value.map((p) => p.path_id)).toEqual([]);
+  });
+});

--- a/src/composables/usePathVisibility.ts
+++ b/src/composables/usePathVisibility.ts
@@ -9,26 +9,45 @@ import {
 } from '../lib/db';
 
 /**
+ * Shared across every usePathVisibility() call — Settings and the day/path
+ * browser views each call this composable independently, and Ionic's
+ * router-outlet keeps previously-visited pages mounted rather than
+ * remounting them. A per-call ref meant toggling visibility in Settings
+ * updated only Settings' own copy: the still-mounted day/path browser never
+ * heard about it. A single module-level ref makes every caller read and
+ * write the same state, so a toggle is visible everywhere immediately.
+ */
+const hiddenByPath = ref<Record<string, boolean>>({});
+
+/**
  * Ordering + show/hide state for a user's paths, persisted locally (Dexie for
  * hidden flags, localStorage for order) since it's a per-device display
  * preference rather than server state. Shared by the main day browser
  * (read-only) and the settings page (which exposes the controls).
  */
 export function usePathVisibility(allPaths: Ref<PathResponse[] | undefined>) {
-  const hiddenByPath = ref<Record<string, boolean>>({});
   const pathOrder = ref<string[]>([]);
 
   watch(
     allPaths,
     async (paths) => {
       if (!paths) return;
+      // Skip paths already loaded into the shared map — re-reading them here
+      // could race a toggleVisibility() write that hasn't reached Dexie yet
+      // and clobber it back to the pre-toggle value.
+      const toLoad = paths.filter((p) => !(p.path_id in hiddenByPath.value));
       const hidden = await Promise.all(
-        paths.map(
+        toLoad.map(
           async (p: PathResponse) =>
             [p.path_id, await isPathHidden(p.path_id)] as const,
         ),
       );
-      hiddenByPath.value = Object.fromEntries(hidden);
+      if (hidden.length > 0) {
+        hiddenByPath.value = {
+          ...hiddenByPath.value,
+          ...Object.fromEntries(hidden),
+        };
+      }
 
       const stored = getPathOrder();
       const ids = paths.map((p: PathResponse) => p.path_id);

--- a/src/lib/authSession.ts
+++ b/src/lib/authSession.ts
@@ -1,5 +1,32 @@
 import { ref } from 'vue';
 import { clearEtags } from './etagStore';
+import type { OAuthCallbackResponse } from '../generated/types';
+
+function loadStoredUser(): OAuthCallbackResponse | null {
+  const stored = localStorage.getItem('user');
+  if (!stored) return null;
+  try {
+    return JSON.parse(stored) as OAuthCallbackResponse;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The signed-in user, shared by every page instead of each one doing its own
+ * one-shot localStorage read in onMounted. That per-page read only ever ran
+ * once: Ionic's ion-router-outlet keeps previously-visited pages mounted
+ * (not destroyed) when navigating away, so a page revisited after logout
+ * kept showing its stale logged-in read. A single reactive ref updates every
+ * consumer immediately, regardless of which pages Ionic happens to be
+ * keeping alive.
+ */
+export const currentUser = ref<OAuthCallbackResponse | null>(loadStoredUser());
+
+export function setCurrentUser(user: OAuthCallbackResponse): void {
+  localStorage.setItem('user', JSON.stringify(user));
+  currentUser.value = user;
+}
 
 /**
  * Flips true when a request comes back 401 — the session is invalid or expired.
@@ -15,6 +42,19 @@ export function clearSession(): void {
   sessionExpired.value = true;
   // Fire-and-forget: a cached response body must never survive to the next
   // account that signs in on this browser.
+  void clearEtags();
+}
+
+/**
+ * A deliberate, user-initiated logout (the Settings "Logout" button) — unlike
+ * clearSession() above, this fully clears currentUser so every page reflects
+ * the logged-out state immediately, since the user explicitly asked to leave
+ * their account rather than having their session merely expire mid-task.
+ */
+export function logout(): void {
+  localStorage.removeItem('user');
+  localStorage.removeItem('session_token');
+  currentUser.value = null;
   void clearEtags();
 }
 

--- a/src/pages/auth.callback.vue
+++ b/src/pages/auth.callback.vue
@@ -27,7 +27,7 @@ import { useRouter, useRoute } from 'vue-router';
 import { useAuthCallback } from '../generated/apiClient';
 import type { OAuthCallbackResponse } from '../generated/types';
 import { describeError } from '../lib/errors';
-import { consumeReturnPath } from '../lib/authSession';
+import { consumeReturnPath, setCurrentUser } from '../lib/authSession';
 
 const router = useRouter();
 const route = useRoute();
@@ -55,7 +55,7 @@ onMounted(async () => {
     if (result.data) {
       const { token, ...safeData } = result.data as OAuthCallbackResponse;
       localStorage.setItem('session_token', token);
-      localStorage.setItem('user', JSON.stringify(safeData));
+      setCurrentUser(safeData as OAuthCallbackResponse);
     }
   } catch (err: unknown) {
     error.value = describeError('complete login', err);

--- a/src/pages/entry.[pathId].[entryId].vue
+++ b/src/pages/entry.[pathId].[entryId].vue
@@ -147,11 +147,8 @@ import EntryImage from '../components/EntryImage.vue';
 import ImageLightbox from '../components/ImageLightbox.vue';
 import { referencedImageFilenames } from '../utils/markdown';
 import { dateViewPath, pathViewPath } from '../utils/viewLinks';
-import type {
-  EntryContentResponse,
-  ImageResponse,
-  OAuthCallbackResponse,
-} from '../generated/types';
+import { currentUser } from '../lib/authSession';
+import type { EntryContentResponse, ImageResponse } from '../generated/types';
 
 const route = useRoute<'/entry.[pathId].[entryId]'>();
 const router = useRouter();
@@ -173,18 +170,6 @@ const cameFromPaths = computed(() => route.query.from === 'paths');
 const entryLinkQuery = computed(() =>
   cameFromPaths.value ? { from: 'paths' } : {},
 );
-
-const currentUser = ref<OAuthCallbackResponse | null>(null);
-onMounted(() => {
-  const stored = localStorage.getItem('user');
-  if (stored) {
-    try {
-      currentUser.value = JSON.parse(stored) as OAuthCallbackResponse;
-    } catch {
-      currentUser.value = null;
-    }
-  }
-});
 
 const { data: allPaths } = usePaths();
 const { visiblePaths } = usePathVisibility(allPaths);

--- a/src/pages/entry.new.vue
+++ b/src/pages/entry.new.vue
@@ -161,29 +161,17 @@ import { useLocalDraft } from '../composables/useLocalDraft';
 import { pickImages } from '../composables/useImagePicker';
 import { usePhotoRemoveConfirm } from '../composables/usePhotoRemoveConfirm';
 import { describeError } from '../lib/errors';
+import { currentUser } from '../lib/authSession';
 import MarkdownContent from '../components/MarkdownContent.vue';
 import PhotoStripItem from '../components/PhotoStripItem.vue';
 import SavingOverlay from '../components/SavingOverlay.vue';
 import { useMarkdownEditor } from '../composables/useMarkdownEditor';
 import { toLocalISODate } from '../utils/date';
 import { dateViewPath, pathViewPath } from '../utils/viewLinks';
-import type { OAuthCallbackResponse } from '../generated/types';
 
 const route = useRoute();
 const router = useRouter();
 const queryClient = useQueryClient();
-
-const currentUser = ref<OAuthCallbackResponse | null>(null);
-onMounted(() => {
-  const stored = localStorage.getItem('user');
-  if (stored) {
-    try {
-      currentUser.value = JSON.parse(stored) as OAuthCallbackResponse;
-    } catch {
-      currentUser.value = null;
-    }
-  }
-});
 
 const { data: allPaths } = usePaths();
 const ownedPaths = computed(

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -66,21 +66,20 @@
 
 <script setup lang="ts">
 import { IonPage, IonContent } from '@ionic/vue';
-import { computed, onMounted, ref } from 'vue';
+import { computed, ref } from 'vue';
 import { useRoute } from 'vue-router';
 
 import DayBrowser from '../components/DayBrowser.vue';
 import BottomBar from '../components/BottomBar.vue';
-import type { OAuthCallbackResponse } from '../generated/types';
 import { usePaths } from '../composables/usePaths';
 import { usePathVisibility } from '../composables/usePathVisibility';
 import { useMultiPathEntries } from '../composables/useMultiPathEntries';
 import { useGoogleLogin } from '../composables/useGoogleLogin';
+import { currentUser } from '../lib/authSession';
 import { toLocalISODate } from '../utils/date';
 
 const route = useRoute();
 const { loggingIn, loginError, loginWithGoogle } = useGoogleLogin();
-const currentUser = ref<OAuthCallbackResponse | null>(null);
 
 const initialDate =
   typeof route.query.day === 'string' ? route.query.day : undefined;
@@ -105,18 +104,6 @@ const canCreateAny = computed(
       (p) => p.owner_user_id === currentUser.value!.user_id,
     ),
 );
-
-onMounted(() => {
-  const stored = localStorage.getItem('user');
-  if (stored) {
-    try {
-      currentUser.value = JSON.parse(stored) as OAuthCallbackResponse;
-    } catch {
-      localStorage.removeItem('user');
-      localStorage.removeItem('session_token');
-    }
-  }
-});
 </script>
 
 <style scoped>

--- a/src/pages/paths.vue
+++ b/src/pages/paths.vue
@@ -27,19 +27,18 @@
 
 <script setup lang="ts">
 import { IonPage, IonContent } from '@ionic/vue';
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 
 import PathBrowser from '../components/PathBrowser.vue';
 import BottomBar from '../components/BottomBar.vue';
-import type { OAuthCallbackResponse } from '../generated/types';
 import { usePaths } from '../composables/usePaths';
 import { usePathVisibility } from '../composables/usePathVisibility';
 import { useMultiPathEntries } from '../composables/useMultiPathEntries';
+import { currentUser } from '../lib/authSession';
 import { toLocalISODate } from '../utils/date';
 
 const route = useRoute();
-const currentUser = ref<OAuthCallbackResponse | null>(null);
 
 const { data: allPaths, isPending: pathsLoading } = usePaths();
 const { visiblePaths } = usePathVisibility(allPaths);
@@ -119,18 +118,6 @@ const canCreateAny = computed(
       (p) => p.owner_user_id === currentUser.value!.user_id,
     ),
 );
-
-onMounted(() => {
-  const stored = localStorage.getItem('user');
-  if (stored) {
-    try {
-      currentUser.value = JSON.parse(stored) as OAuthCallbackResponse;
-    } catch {
-      localStorage.removeItem('user');
-      localStorage.removeItem('session_token');
-    }
-  }
-});
 </script>
 
 <style scoped>

--- a/src/pages/settings.vue
+++ b/src/pages/settings.vue
@@ -11,7 +11,7 @@
             <span v-if="currentUser" class="settings-username">{{
               currentUser.display_name || currentUser.user_id
             }}</span>
-            <button class="text-link" @click="logout">Logout</button>
+            <button class="text-link" @click="handleLogout">Logout</button>
           </div>
         </div>
 
@@ -244,7 +244,7 @@
 
 <script setup lang="ts">
 import { IonPage, IonContent } from '@ionic/vue';
-import { computed, onMounted, ref } from 'vue';
+import { computed, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { useQueryClient } from '@tanstack/vue-query';
 
@@ -259,30 +259,22 @@ import {
 } from '../generated/apiClient';
 import { usePaths } from '../composables/usePaths';
 import { usePathVisibility } from '../composables/usePathVisibility';
+import { currentUser, logout } from '../lib/authSession';
 import ExportCard from '../components/ExportCard.vue';
 import PathFormModal from '../components/PathFormModal.vue';
 import PathDeleteModal from '../components/PathDeleteModal.vue';
 import PathShareModal from '../components/PathShareModal.vue';
-import type { OAuthCallbackResponse, PathResponse } from '../generated/types';
+import type { PathResponse } from '../generated/types';
 
 const router = useRouter();
 const queryClient = useQueryClient();
 
-const currentUser = ref<OAuthCallbackResponse | null>(null);
-onMounted(() => {
-  const stored = localStorage.getItem('user');
-  if (stored) {
-    try {
-      currentUser.value = JSON.parse(stored) as OAuthCallbackResponse;
-    } catch {
-      currentUser.value = null;
-    }
-  }
-});
-
-function logout() {
-  localStorage.removeItem('user');
-  localStorage.removeItem('session_token');
+function handleLogout() {
+  logout();
+  // Drop every cached response body (in-memory and its IndexedDB persistence)
+  // so a shared browser never shows the next signed-in account stale data
+  // from this one.
+  queryClient.clear();
   router.replace('/');
 }
 


### PR DESCRIPTION
Both bugs share the same root cause: Ionic's ion-router-outlet keeps
previously-visited pages mounted rather than remounting them, but every
page read its current user and hidden-path preferences into a private,
one-shot ref (set once in onMounted or on first watch). A page revisited
after another page changed that state never re-read it.

- lib/authSession.ts: add a shared `currentUser` ref plus setCurrentUser()/
  logout() so every page reflects a login or logout immediately. All pages
  that used to parse localStorage('user') in their own onMounted now import
  this shared ref instead.
- settings.vue: wire the Logout button to the new logout() and clear the
  query cache, instead of only removing localStorage keys and closing the
  page.
- composables/usePathVisibility.ts: make hiddenByPath a module-level ref
  shared by every usePathVisibility() call (Settings and the Week/Paths
  views each called it independently), so toggling a path's visibility in
  Settings is reflected in an already-open Week/Paths view right away.

Also applied the same shared-currentUser fix to entry.new.vue and the
entry detail page for consistency, since they had the identical one-shot
localStorage-read pattern; this may also help the reported "new path
missing from the write-entry dropdown" symptom, though I could not pin a
distinct root cause for that one through static analysis alone — worth
confirming by hand.

Added regression tests for both fixes.